### PR TITLE
Allow trino catalog override

### DIFF
--- a/internal/pkg/object/command/trino/client.go
+++ b/internal/pkg/object/command/trino/client.go
@@ -62,6 +62,12 @@ func newRequest(r *plugin.Runtime, j *job.Job, c *cluster.Cluster) (*request, er
 			return nil, err
 		}
 	}
+
+	catalog := clusterCtx.Catalog
+	if jobCtx.Catalog != "" {
+		catalog = jobCtx.Catalog
+	}
+
 	jobCtx.Query = normalizeTrinoQuery(jobCtx.Query)
 
 	// form context for trino request
@@ -72,7 +78,7 @@ func newRequest(r *plugin.Runtime, j *job.Job, c *cluster.Cluster) (*request, er
 			`User-Agent`:      []string{r.UserAgent},
 			`X-Trino-User`:    []string{j.User},
 			`X-Trino-Source`:  []string{r.UserAgent},
-			`X-Trino-Catalog`: []string{clusterCtx.Catalog},
+			`X-Trino-Catalog`: []string{catalog},
 		},
 		userAgent: r.UserAgent,
 		client:    &http.Client{},

--- a/internal/pkg/object/command/trino/trino.go
+++ b/internal/pkg/object/command/trino/trino.go
@@ -25,7 +25,8 @@ type clusterContext struct {
 }
 
 type jobContext struct {
-	Query string `yaml:"query" json:"query"`
+	Query   string `yaml:"query" json:"query"`
+	Catalog string `yaml:"catalog,omitempty" json:"catalog,omitempty"`
 }
 
 // New creates a new trino plugin handler


### PR DESCRIPTION
Trino allows connections to different RDS instances by configuring a separate catalog for each database. Each catalog can only connect to a single database. In current Heimdall  implementation each cluster holds different catalog and as a result if a new Trino catalog was added new cluster and command should be added to config.

To improve the user experience, we propose allowing users to dynamically override the target catalog as part of the task definition, rather than statically configuring all catalogs in advance.

This enhancement was tested successfully on a local build.