### PR TITLE
Allow to store results in async mode

### DIFF
--- a/assets/databases/heimdall/tables/jobs.sql
+++ b/assets/databases/heimdall/tables/jobs.sql
@@ -12,8 +12,11 @@ create table if not exists jobs
     job_error varchar(1024) null,
     username varchar(64) not null,
     is_sync boolean not null,
+    store_result_sync boolean not null default false,
     created_at int not null default extract(epoch from now())::int,
     updated_at int not null default extract(epoch from now())::int,
     constraint _jobs_pk primary key (system_job_id),
     constraint _jobs_job_id unique (job_id)
 );
+
+alter table jobs add column if not exists store_result_sync boolean not null default false;

--- a/configs/local.yaml
+++ b/configs/local.yaml
@@ -23,6 +23,7 @@ commands:
     status: active
     plugin: ping
     version: 0.0.1
+    store_result_sync: false
     description: Test ping command
     tags:
       - type:ping

--- a/internal/pkg/heimdall/job_dal.go
+++ b/internal/pkg/heimdall/job_dal.go
@@ -100,7 +100,7 @@ func (h *Heimdall) insertJob(j *job.Job, clusterID, commandID string) (int64, er
 	defer sess.Close()
 
 	// insert job row
-	jobID, err := sess.InsertRow(queryJobInsert, clusterID, commandID, j.Status, j.ID, j.Name, j.Version, j.Description, j.Context.String(), j.Error, j.User, j.IsSync)
+	jobID, err := sess.InsertRow(queryJobInsert, clusterID, commandID, j.Status, j.ID, j.Name, j.Version, j.Description, j.Context.String(), j.Error, j.User, j.IsSync, j.StoreResultSync)
 	if err != nil {
 		return 0, err
 	}
@@ -180,7 +180,7 @@ func (h *Heimdall) getJob(j *jobRequest) (any, error) {
 	var jobContext string
 
 	if err := row.Scan(&r.SystemID, &r.Status, &r.Name, &r.Version, &r.Description, &jobContext, &r.Error, &r.User, &r.IsSync,
-		&r.CreatedAt, &r.UpdatedAt, &r.CommandID, &r.CommandName, &r.CluserID, &r.ClusterName); err != nil {
+		&r.CreatedAt, &r.UpdatedAt, &r.CommandID, &r.CommandName, &r.CluserID, &r.ClusterName, &r.StoreResultSync); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ErrUnknownJobID
 		} else {
@@ -224,7 +224,7 @@ func (h *Heimdall) getJobs(f *database.Filter) (any, error) {
 		r := &job.Job{}
 
 		if err := rows.Scan(&r.SystemID, &r.ID, &r.Status, &r.Name, &r.Version, &r.Description, &jobContext, &r.Error, &r.User, &r.IsSync,
-			&r.CreatedAt, &r.UpdatedAt, &r.CommandID, &r.CommandName, &r.CluserID, &r.ClusterName); err != nil {
+			&r.CreatedAt, &r.UpdatedAt, &r.CommandID, &r.CommandName, &r.CluserID, &r.ClusterName, &r.StoreResultSync); err != nil {
 			return nil, err
 		}
 

--- a/internal/pkg/heimdall/jobs_async.go
+++ b/internal/pkg/heimdall/jobs_async.go
@@ -51,7 +51,7 @@ func (h *Heimdall) getAsyncJobs(limit int) ([]*job.Job, error) {
 		jobContext, j := ``, &job.Job{}
 
 		if err := rows.Scan(&j.SystemID, &j.CommandID, &j.CluserID, &j.Status, &j.ID, &j.Name,
-			&j.Version, &j.Description, &jobContext, &j.User, &j.IsSync, &j.CreatedAt, &j.UpdatedAt); err != nil {
+			&j.Version, &j.Description, &jobContext, &j.User, &j.IsSync, &j.CreatedAt, &j.UpdatedAt, &j.StoreResultSync); err != nil {
 			return nil, err
 		}
 

--- a/internal/pkg/heimdall/queries/job/active_select.sql
+++ b/internal/pkg/heimdall/queries/job/active_select.sql
@@ -13,7 +13,8 @@ with a as
         jj.username,
         jj.is_sync,
         jj.created_at,
-        jj.updated_at
+        jj.updated_at,
+        jj.store_result_sync
     from
         active_jobs aj
         join jobs jj on jj.system_job_id = aj.system_job_id
@@ -49,4 +50,5 @@ returning
     a.username,
     a.is_sync,
     a.created_at,
-    a.updated_at;
+    a.updated_at,
+    a.store_result_sync;

--- a/internal/pkg/heimdall/queries/job/insert.sql
+++ b/internal/pkg/heimdall/queries/job/insert.sql
@@ -10,7 +10,8 @@ insert into jobs
     job_context,
     job_error,
     username,
-    is_sync
+    is_sync,
+    store_result_sync
 )
 select
     cm.system_command_id,
@@ -23,7 +24,8 @@ select
     $8, -- job_context
     $9, -- job_error
     $10, -- username
-    $11 -- is_sync
+    $11, -- is_sync
+    $12 -- store_result_sync
 from
     clusters cl,
     commands cm

--- a/internal/pkg/heimdall/queries/job/select.sql
+++ b/internal/pkg/heimdall/queries/job/select.sql
@@ -13,7 +13,8 @@ select
     cm.command_id,
     cm.command_name,
     cl.cluster_id,
-    cl.cluster_name
+    cl.cluster_name,
+    j.store_result_sync
 from
     jobs j
     left join commands cm on cm.system_command_id = j.job_command_id

--- a/internal/pkg/heimdall/queries/job/select_jobs.sql
+++ b/internal/pkg/heimdall/queries/job/select_jobs.sql
@@ -14,7 +14,8 @@ select
     cm.command_id,
     cm.command_name,
     cl.cluster_id,
-    cl.cluster_name
+    cl.cluster_name,
+    j.store_result_sync
 from
     jobs j
     join job_statuses js on js.job_status_id = j.job_status_id

--- a/pkg/object/job/job.go
+++ b/pkg/object/job/job.go
@@ -13,6 +13,7 @@ type Job struct {
 	object.Object   `yaml:",inline" json:",inline"`
 	Status          status.Status    `yaml:"status,omitempty" json:"status,omitempty"`
 	IsSync          bool             `yaml:"is_sync,omitempty" json:"is_sync,omitempty"`
+	StoreResultSync bool             `yaml:"store_result_sync,omitempty" json:"store_result_sync,omitempty"`
 	Error           string           `yaml:"error,omitempty" json:"error,omitempty"`
 	CommandCriteria *set.Set[string] `yaml:"command_criteria,omitempty" json:"command_criteria,omitempty"`
 	ClusterCriteria *set.Set[string] `yaml:"cluster_criteria,omitempty" json:"cluster_criteria,omitempty"`


### PR DESCRIPTION
**Background**
Heimdall currently supports storing job results either locally or in S3, with S3 being the typical choice for production. At present, results are always stored synchronously - even for synchronous jobs - leading to additional latency being introduced by the upload process. This synchronous storage can critically impact performance in cases where low-latency job execution is required.

**Changes**
This PR introduces a new field, store_result_async, on the job model. When enabled, this allows Heimdall to store job results in a separate goroutine, effectively making the storage operation asynchronous. With this approach, a job can finish execution and return success to the client while the result upload continues in the background. 
**Note**: This means there is a possibility that a job may be marked as successful even if the result storage to S3 fails.

**Testing**
**Performance**:
- Performance tests were conducted locally, with Heimdall configured to use an external S3 bucket.
  - In synchronous mode, job execution latency was measured at approximately 180ms.
  - In asynchronous mode, job execution latency dropped to around 0.6ms, with the S3 upload taking ~180ms in the background.

**Migration**:
Migration testing was performed by creating a fresh database, running Heimdall, and then applying the migration script to validate database updates.

<img width="422" height="229" alt="Screenshot 2025-08-15 at 11 35 15 AM" src="https://github.com/user-attachments/assets/9bc6d5d0-2d68-471b-a1d2-e222838255d1" />
