### PR TITLE
Update docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.24.6
 
 RUN apt-get update && apt-get install -y nodejs npm awscli jq
-
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential binutils binutils-gold pkg-config && rm -rf /var/lib/apt/lists/*
 WORKDIR /go/src/github.com/patterninc/heimdall
 
 COPY . .
@@ -9,7 +9,6 @@ COPY . .
 # set config file
 COPY configs/local.yaml /etc/heimdall/heimdall.yaml
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-
 # build executables
 RUN ./build.sh
 


### PR DESCRIPTION
Something changed in docker image golang:1.24.6 and it doesn't have required libraries now. So we have to install libraries 

Everything was tested on local machine 