### PR TITLE
Add sql parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/otel v1.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 h1:zzrxE1FKn5ryBNl9eKOeqQ58Y/Qpo3Q9QNxKHX5uzzQ=
+github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2/go.mod h1:hzfGeIUDq/j97IG+FhNqkowIyEcD88LrW6fyU3K3WqY=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=

--- a/internal/pkg/sql/parser.go
+++ b/internal/pkg/sql/parser.go
@@ -1,0 +1,319 @@
+package sql
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/xwb1989/sqlparser"
+)
+
+type accessType string
+
+const (
+	Select accessType = "select"
+	Insert accessType = "insert"
+	Update accessType = "update"
+	Delete accessType = "delete"
+)
+
+type ResourceAccess struct {
+	AccessType string `json:"access_type"`
+	Schema     string `json:"schema"`
+	Table      string `json:"table"`
+}
+
+// ParseSQLToResourceAccess parses a SQL query string and extracts resource access information
+// for each statement found in the query. It supports SELECT, INSERT, DELETE, and DDL statements,
+// and returns a slice of ResourceAccess pointers representing the accessed resources and their
+// access types. Unsupported or unhandled statement types are skipped, except for unknown types,
+// which result in an error. If parsing or processing any statement fails, an error is returned.
+//
+// Parameters:
+//   - query: The SQL query string to parse.
+//
+// Returns:
+//   - []*ResourceAccess: A slice of pointers to ResourceAccess structs describing the accessed resources.
+//   - error: An error if parsing or processing fails, or nil on success.
+func ParseSQLToResourceAccess(query string) ([]*ResourceAccess, error) {
+	query = normalizeQuery(query)
+	tokens := sqlparser.NewTokenizer(bytes.NewReader([]byte(query)))
+
+	var result []*ResourceAccess
+	for {
+		stmt, err := sqlparser.ParseNext(tokens)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse SQL: %w", err)
+		}
+		switch stmt := stmt.(type) {
+		case *sqlparser.Select:
+			selectStatements, err := processSelectStatement(stmt)
+			if err != nil {
+				return nil, fmt.Errorf("failed to process select statement: %w", err)
+			}
+			result = append(result, selectStatements...)
+
+		case *sqlparser.Insert:
+			insertStatements, err := processInsertStatement(stmt)
+			if err != nil {
+				return nil, fmt.Errorf("failed to process insert statement: %w", err)
+			}
+			result = append(result, insertStatements...)
+		case *sqlparser.Update:
+			continue
+		case *sqlparser.Delete:
+			deleteResult, err := processDeleteStatement(stmt)
+			if err != nil {
+				return nil, fmt.Errorf("failed to process delete statement: %w", err)
+			}
+			result = append(result, deleteResult...)
+
+		case *sqlparser.DBDDL: // DBDDL represents a CREATE, DROP database statement.
+			continue
+		case *sqlparser.DDL: // DDL represents a CREATE, ALTER, DROP, RENAME or TRUNCATE statement.
+			result = append(result, &ResourceAccess{
+				AccessType: string(stmt.Action),
+				Schema:     stmt.NewName.Qualifier.String(),
+				Table:      stmt.NewName.Name.String(),
+			})
+			ddlResult, err := processExpr(stmt.TableSpec, accessType(stmt.Action))
+			if err != nil {
+				return nil, fmt.Errorf("failed to process DDL statement: %w", err)
+			}
+			result = append(result, ddlResult...)
+
+			continue
+		case *sqlparser.Set: // Set represents a SET statement.
+			continue
+		case *sqlparser.Show: // Show represents a SHOW statement.
+			continue
+		case *sqlparser.Use: // Use represents a USE statement.
+			continue
+		default:
+			return nil, fmt.Errorf("unsupported statement type: %T", stmt)
+		}
+	}
+	return result, nil
+}
+
+func processDeleteStatement(stmt *sqlparser.Delete) ([]*ResourceAccess, error) {
+	var result []*ResourceAccess
+	accessTypeForTableExprs := Delete
+	for _, tbl := range stmt.Targets {
+		tableName := tbl.Name.String()
+		schemaName := tbl.Qualifier.String()
+		if schemaName == "" {
+			continue
+		}
+		accessTypeForTableExprs = Select
+		result = append(result, &ResourceAccess{
+			AccessType: string(Delete),
+			Schema:     schemaName,
+			Table:      tableName,
+		})
+	}
+
+	for _, tbl := range stmt.TableExprs {
+		tblResult, err := processExpr(tbl, accessTypeForTableExprs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process delete statement: %w", err)
+		}
+		result = append(result, tblResult...)
+	}
+
+	if stmt.Where != nil {
+		whereResult, err := processExpr(stmt.Where.Expr, Select)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process delete where clause: %w", err)
+		}
+		result = append(result, whereResult...)
+	}
+	return result, nil
+}
+
+func processInsertStatement(stmt *sqlparser.Insert) ([]*ResourceAccess, error) {
+	result, err := processExpr(stmt.Rows, Select)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process insert statement: %w", err)
+	}
+	tableName := stmt.Table.Name.String()
+	schemaName := stmt.Table.Qualifier.String()
+
+	if schemaName == "" {
+		return nil, nil
+	}
+
+	resourceAccess := &ResourceAccess{
+		AccessType: "insert",
+		Schema:     schemaName,
+		Table:      tableName,
+	}
+	result = append(result, resourceAccess)
+	return result, nil
+}
+
+func processSelectStatement(stmt *sqlparser.Select) ([]*ResourceAccess, error) {
+	var result []*ResourceAccess
+	var err error
+	var resourceAccesses []*ResourceAccess
+	for _, tbl := range stmt.From {
+		result, err = processExpr(tbl, Select)
+		if err != nil {
+			return nil, err
+		}
+		resourceAccesses = append(resourceAccesses, result...)
+
+	}
+	if stmt.Where != nil {
+		result, err = processExpr(stmt.Where.Expr, Select)
+		if err != nil {
+			return nil, err
+		}
+		resourceAccesses = append(resourceAccesses, result...)
+	}
+	if stmt.Having != nil && stmt.Having.Expr != nil {
+		result, err = processExpr(stmt.Having.Expr, Select)
+		if err != nil {
+			return nil, err
+		}
+		resourceAccesses = append(resourceAccesses, result...)
+	}
+
+	return resourceAccesses, nil
+}
+
+func processExpr(expr sqlparser.SQLNode, accessType accessType) ([]*ResourceAccess, error) {
+	if expr == nil {
+		return nil, nil
+	}
+	var result []*ResourceAccess
+	switch node := expr.(type) {
+	case *sqlparser.AliasedTableExpr:
+		return processExpr(node.Expr, accessType)
+	case *sqlparser.JoinTableExpr:
+		// Recursively process left and right sides of the join
+		leftResult, err := processExpr(node.LeftExpr, accessType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process join left expression: %w", err)
+		}
+		result = append(result, leftResult...)
+		rightResult, err := processExpr(node.RightExpr, Select) // in join right table is usually SELECT
+		if err != nil {
+			return nil, fmt.Errorf("failed to process join right expression: %w", err)
+		}
+		result = append(result, rightResult...)
+	case *sqlparser.ComparisonExpr:
+		// Recursively process left and right sides of the comparison
+		leftResult, err := processExpr(node.Left, accessType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process comparison left expression: %w", err)
+		}
+		result = append(result, leftResult...)
+		rightResult, err := processExpr(node.Right, accessType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process comparison right expression: %w", err)
+		}
+		result = append(result, rightResult...)
+	case *sqlparser.ColName:
+		// heimdall doesn't need column support for now
+		return nil, nil
+	case *sqlparser.Subquery:
+		return processExpr(node.Select, accessType)
+	case *sqlparser.Select:
+		return processSelectStatement(node)
+	case sqlparser.TableName:
+		if node.Qualifier.IsEmpty() {
+			return nil, fmt.Errorf("table name must be fully qualified")
+		}
+		tableName := node.Name.String()
+		result = append(result, &ResourceAccess{
+			AccessType: string(accessType),
+			Schema:     node.Qualifier.String(),
+			Table:      tableName,
+		})
+
+	case *sqlparser.ExistsExpr:
+		return processExpr(node.Subquery, accessType)
+	case sqlparser.Values:
+		for _, valTuple := range node {
+			tableResults, err := processExpr(valTuple, accessType)
+			if err != nil {
+				return nil, fmt.Errorf("failed to process values row: %w", err)
+			}
+			result = append(result, tableResults...)
+		}
+	case sqlparser.ValTuple:
+		for _, val := range node {
+			valResult, err := processExpr(val, accessType)
+			if err != nil {
+				return nil, fmt.Errorf("failed to process value tuple: %w", err)
+			}
+			result = append(result, valResult...)
+		}
+	case *sqlparser.SQLVal:
+		// heimdall doesn't need SQLVal support for now
+		return nil, nil
+	case *sqlparser.AndExpr:
+		leftResult, err := processExpr(node.Left, accessType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process AND expression left side: %w", err)
+		}
+		result = append(result, leftResult...)
+		rightResult, err := processExpr(node.Right, accessType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process AND expression right side: %w", err)
+		}
+		result = append(result, rightResult...)
+	case *sqlparser.OrExpr:
+		leftResult, err := processExpr(node.Left, accessType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process OR expression left side: %w", err)
+		}
+		result = append(result, leftResult...)
+		rightResult, err := processExpr(node.Right, accessType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process OR expression right side: %w", err)
+		}
+		result = append(result, rightResult...)
+	case *sqlparser.NotExpr:
+		notResult, err := processExpr(node.Expr, accessType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process NOT expression: %w", err)
+		}
+		result = append(result, notResult...)
+	case *sqlparser.IsExpr:
+		isResult, err := processExpr(node.Expr, accessType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process IS expression: %w", err)
+		}
+		result = append(result, isResult...)
+	case *sqlparser.ParenExpr:
+		return processExpr(node.Expr, accessType)
+	case *sqlparser.TableSpec:
+		// TableSpec is used in DDL statements we don't need to handle it now
+		return result, nil
+	case sqlparser.TableExprs:
+		for _, tbl := range node {
+			tblResult, err := processExpr(tbl, accessType)
+			if err != nil {
+				return nil, fmt.Errorf("failed to process table expression: %w", err)
+			}
+			result = append(result, tblResult...)
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported expr type: %T", node)
+	}
+	return result, nil
+}
+
+func normalizeQuery(query string) string {
+
+	// sqlparser doesn't support TEMPORARY VIEW, so we replace it with VIEW
+	return strings.ReplaceAll(query, "TEMPORARY VIEW", "VIEW")
+
+}

--- a/internal/pkg/sql/tests/create_test.go
+++ b/internal/pkg/sql/tests/create_test.go
@@ -1,0 +1,104 @@
+package sql
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/patterninc/heimdall/internal/pkg/sql"
+)
+
+func TestParseSQLCreate(t *testing.T) {
+	type testCase struct {
+		name     string
+		query    string
+		expected []*sql.ResourceAccess
+	}
+	tests := []testCase{
+		{
+			name:  "Create table with schema",
+			query: "CREATE TABLE myschema.mytable (id INT, name VARCHAR(100))",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "create",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Create table with quoted schema and table",
+			query: "CREATE TABLE `myschema`.`mytable` (id INT, name VARCHAR(100))",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "create",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Create table with IF NOT EXISTS",
+			query: "CREATE TABLE IF NOT EXISTS myschema.mytable (id INT)",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "create",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Create table with complex column types",
+			query: "CREATE TABLE public.mytable (id SERIAL PRIMARY KEY, data JSONB)",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "create",
+					Schema:     "public",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name: "Create view from csv files",
+			query: `CREATE OR REPLACE VIEW myschema.myview
+					USING CSV
+					OPTIONS (
+  						path 's3://heimdall/*.csv',
+  						header 'true'
+					);`,
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "create",
+					Schema:     "myschema",
+					Table:      "myview",
+				},
+			},
+		},
+		{
+			name:  "Create table using iceberg",
+			query: `CREATE TABLE IF NOT EXISTS myschema.mytable (id int) using iceberg`,
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "create",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := sql.ParseSQLToResourceAccess(tt.query)
+			if err != nil {
+				t.Errorf("Unexpected error in test %s: %v", tt.name, err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				expectedBytes, _ := json.Marshal(tt.expected)
+				resultBytes, _ := json.Marshal(result)
+				t.Errorf("test %s: expected %+v, got %+v", tt.name, string(expectedBytes), string(resultBytes))
+			}
+		})
+	}
+}

--- a/internal/pkg/sql/tests/delete_test.go
+++ b/internal/pkg/sql/tests/delete_test.go
@@ -1,0 +1,218 @@
+package sql
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/patterninc/heimdall/internal/pkg/sql"
+)
+
+func TestParseSQLDelete(t *testing.T) {
+	type testCase struct {
+		name     string
+		query    string
+		expected []*sql.ResourceAccess
+	}
+	tests := []testCase{
+		{
+			name:  "Delete from single table",
+			query: "DELETE FROM myschema.mytable WHERE col1 = 'value1'",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "delete",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Delete with join",
+			query: "DELETE a FROM myschema.mytable a JOIN myschema2.mytable2 b ON a.id = b.id WHERE b.col1 = 'value1'",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "delete",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+			},
+		},
+		{
+			name:  "Delete with subquery",
+			query: "DELETE FROM myschema.mytable WHERE id IN (SELECT id FROM myschema2.mytable2)",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "delete",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+			},
+		},
+		{
+			name:  "Delete with multiple conditions",
+			query: "DELETE FROM myschema.mytable WHERE col1 = 'value1' AND col2 = 'value2'",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "delete",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Delete with complex condition",
+			query: "DELETE FROM myschema.mytable WHERE col1 = 'value1' OR (col2 = 'value2' AND col3 = 'value3')",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "delete",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Delete without where clause",
+			query: "DELETE FROM myschema.mytable",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "delete",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Delete with alias and subquery",
+			query: "DELETE a FROM myschema.mytable a WHERE a.id IN (SELECT b.id FROM myschema2.mytable2 b WHERE b.flag = 1)",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "delete",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+			},
+		},
+		{
+			name:  "Delete with exists subquery",
+			query: "DELETE FROM myschema.mytable WHERE EXISTS (SELECT 1 FROM myschema2.mytable2 WHERE mytable.id = mytable2.id)",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "delete",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+			},
+		},
+		{
+			name:  "Delete with using clause",
+			query: "DELETE FROM myschema.mytable USING myschema2.mytable2 WHERE myschema.mytable.id = myschema2.mytable2.id",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "delete",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+			},
+		},
+		{
+			name:  "Delete from table with quoted identifiers",
+			query: "DELETE FROM `myschema`.`mytable` WHERE `col1` = `value1`",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "delete",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Delete with limit",
+			query: "DELETE FROM myschema.mytable WHERE col1 = 'value1' LIMIT 10",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "delete",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Delete with order by",
+			query: "DELETE FROM myschema.mytable WHERE col1 = 'value1' ORDER BY col2 DESC",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "delete",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name: "Delete with multiple tables",
+			query: `DELETE myschema.mytable, myschema2.mytable2 
+			FROM myschema.mytable JOIN myschema2.mytable2 ON myschema.mytable.id = myschema2.mytable2.id`,
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "delete",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "delete",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := sql.ParseSQLToResourceAccess(tt.query)
+			if err != nil {
+				t.Errorf("Unexpected error in test %s: %v", tt.name, err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				expectedBytes, _ := json.Marshal(tt.expected)
+				resultBytes, _ := json.Marshal(result)
+				t.Errorf("test %s: expected %+v, got %+v", tt.name, string(expectedBytes), string(resultBytes))
+			}
+		})
+	}
+}

--- a/internal/pkg/sql/tests/insert_test.go
+++ b/internal/pkg/sql/tests/insert_test.go
@@ -1,0 +1,170 @@
+package sql
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/patterninc/heimdall/internal/pkg/sql"
+)
+
+func TestParseSQLInsert(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		expected []*sql.ResourceAccess
+	}{
+		{
+			name:  "Insert into single table",
+			query: "INSERT INTO myschema.mytable (col1, col2) VALUES ('value1', 'value2')",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "insert",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Insert with select subquery",
+			query: "INSERT INTO myschema.mytable (col1) SELECT col1 FROM myschema2.mytable2",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+				{
+					AccessType: "insert",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Insert into table with schema and columns",
+			query: "INSERT INTO myschema.mytable (col1, col2, col3) VALUES (1, 2, 3)",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "insert",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Insert ignore",
+			query: "INSERT IGNORE INTO myschema.mytable (col1) VALUES ('a')",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "insert",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Insert with on duplicate key update",
+			query: "INSERT INTO myschema.mytable (col1) VALUES ('a') ON DUPLICATE KEY UPDATE col1 = 'b'",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "insert",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:     "Insert into table without schema",
+			query:    "INSERT INTO mytable (col1) VALUES ('a')",
+			expected: nil,
+		},
+		{
+			name:  "Insert multiple rows",
+			query: "INSERT INTO myschema.mytable (col1, col2) VALUES ('a', 'b'), ('c', 'd')",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "insert",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Insert select with join",
+			query: "INSERT INTO myschema.mytable (col1) SELECT t1.col1 FROM myschema2.mytable2 t1 JOIN myschema3.mytable3 t2 ON t1.id = t2.id",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema3",
+					Table:      "mytable3",
+				},
+				{
+					AccessType: "insert",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name: "Insert from SELECT with WHERE, AND, OR and IS clauses",
+			query: `
+				INSERT INTO myschema.mytable (col1)
+				SELECT col1 FROM myschema2.mytable2
+				WHERE col2 = (SELECT col2 FROM myschema3.mytable3 WHERE col2 = 'value2')
+				AND (
+					col2 = (SELECT col2 FROM myschema3.mytable3 WHERE col2 = 'value2') OR 
+					col3 IS NOT NULL
+				)
+				AND col4 NOT IN (SELECT col4 FROM myschema4.mytable4 WHERE col4 = 'value4')
+			`,
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema3",
+					Table:      "mytable3",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema3",
+					Table:      "mytable3",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema4",
+					Table:      "mytable4",
+				},
+				{
+					AccessType: "insert",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := sql.ParseSQLToResourceAccess(tt.query)
+			if err != nil {
+				t.Errorf("Unexpected error in test %s: %v", tt.name, err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				expectedBytes, _ := json.Marshal(tt.expected)
+				resultBytes, _ := json.Marshal(result)
+				t.Errorf("test %s: expected %+v, got %+v", tt.name, string(expectedBytes), string(resultBytes))
+			}
+		})
+	}
+}

--- a/internal/pkg/sql/tests/select_test.go
+++ b/internal/pkg/sql/tests/select_test.go
@@ -1,0 +1,190 @@
+package sql
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/patterninc/heimdall/internal/pkg/sql"
+)
+
+func TestParseSQLSelect(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		expected []*sql.ResourceAccess
+	}{
+		{
+			name:  "Single table",
+			query: "SELECT * FROM myschema.mytable",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "select",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+			},
+		},
+		{
+			name:  "Multiple tables",
+			query: "SELECT * FROM myschema.mytable, myschema2.mytable2",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "select",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+			},
+		},
+		{
+			name:  "Join tables",
+			query: "SELECT * FROM ( SELECT * FROM myschema.mytable, myschema2.mytable2 )as b",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "select",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+			},
+		},
+		{
+			name:  "Join with ON clause",
+			query: "SELECT a.col1, b.col2 FROM myschema.mytable a JOIN myschema2.mytable2 b ON a.id = b.id",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "select",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+			},
+		},
+		{
+			name:  "Subquery in FROM clause",
+			query: "SELECT * FROM myschema.mytable WHERE id IN (SELECT id FROM myschema2.mytable2)",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "select",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+			},
+		},
+		{
+			name:  "Subquery with alias",
+			query: "SELECT * FROM (SELECT * FROM myschema.mytable WHERE id IN (SELECT id FROM myschema2.mytable2)) as sub",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "select",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+			},
+		},
+		{
+			name:  "Complex query with multiple joins and subqueries",
+			query: "SELECT * FROM myschema.mytable LEFT JOIN myschema2.mytable2 ON myschema.mytable.id = myschema2.mytable2.id",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "select",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+			},
+		},
+		{
+			name:  "EXISTS subquery",
+			query: "SELECT * FROM myschema.mytable WHERE EXISTS (SELECT 1 FROM myschema2.mytable2 WHERE myschema2.mytable2.id = myschema.mytable.id)",
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "select",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+			},
+		},
+		{
+			name: "Select with WHERE, AND, OR and IS clauses",
+			query: `
+				SELECT * FROM myschema.mytable  
+				WHERE col1 = (SELECT col1 FROM myschema2.mytable2 WHERE col2 = 'value2')
+				AND (
+					col2 = (SELECT col2 FROM myschema3.mytable3 WHERE col2 = 'value2') OR 
+					col3 IS NOT NULL
+				)
+				AND col4 NOT IN (SELECT col4 FROM myschema4.mytable4 WHERE col4 = 'value4')
+			`,
+			expected: []*sql.ResourceAccess{
+				{
+					AccessType: "select",
+					Schema:     "myschema",
+					Table:      "mytable",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema2",
+					Table:      "mytable2",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema3",
+					Table:      "mytable3",
+				},
+				{
+					AccessType: "select",
+					Schema:     "myschema4",
+					Table:      "mytable4",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := sql.ParseSQLToResourceAccess(tt.query)
+			if err != nil {
+				t.Errorf("Unexpected error in test %s: %v", tt.name, err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				expectedBytes, _ := json.Marshal(tt.expected)
+				resultBytes, _ := json.Marshal(result)
+				t.Errorf("test %s: expected %+v, got %+v", tt.name, string(expectedBytes), string(resultBytes))
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Background**
Heimdall doesn't support RBAC for any cluster now.  It should be changed

**Changes**
This PR is a first PR in a big chain of PRs for supporting RBAC inside Heimdall. 
As a first step parser for SQL queries were added. 
Eventually results of this parser will be converted to the Ranger's requests. 

**Tests**
Unit tests. 