### PR TITLE
fix(heimdall): display job properties in UI

### DIFF
--- a/web/src/modules/Jobs/Helper.tsx
+++ b/web/src/modules/Jobs/Helper.tsx
@@ -38,12 +38,14 @@ export type JobType = {
   cluster_name: string
   error?: string
   context?: {
+    parameters: {
     properties: {
       'spark.driver.cores': string
       'spark.driver.memory': string
       'spark.executor.cores': string
-      'spark.executor.instances': string
-      'spark.executor.memory': string
+        'spark.executor.instances': string
+        'spark.executor.memory': string
+      }
     }
     query: string
     return_result?: boolean

--- a/web/src/modules/Jobs/JobDetails/JobDetailsHeader.tsx
+++ b/web/src/modules/Jobs/JobDetails/JobDetailsHeader.tsx
@@ -23,11 +23,11 @@ const JobDetailsHeader = ({
               {jobData?.status === 'FAILED' ? (
                 <Alert type='error' text={jobData?.error} />
               ) : null}
-              {jobData?.context?.properties ? (
+              {jobData?.context?.parameters?.properties ? (
                 <div>
                   <SectionHeader title='Context' />
                   <ul>
-                    {Object.entries(jobData?.context?.properties || {}).map(
+                    {Object.entries(jobData?.context?.parameters?.properties || {}).map(
                       ([key, value]) => (
                         <li key={key}>
                           {key}:{value}


### PR DESCRIPTION
This pull request updates how job context properties are accessed and structured in the job-related components. The main change is introducing a new `parameters` object inside the `context` field of the `JobType`, and updating all references to job context properties to use this new structure.

**Type and data structure updates:**

* Updated the `JobType` type definition in `Helper.tsx` to nest `properties` inside a new `parameters` object within `context`.

**Component logic updates:**

* Modified `JobDetailsHeader.tsx` to reference `jobData.context.parameters.properties` instead of `jobData.context.properties` when displaying job context properties.