### PR TITLE
Add Job related metrics

### DIFF
--- a/internal/pkg/heimdall/job.go
+++ b/internal/pkg/heimdall/job.go
@@ -79,7 +79,6 @@ func (h *Heimdall) submitJob(j *job.Job) (any, error) {
 func (h *Heimdall) runJob(job *job.Job, command *command.Command, cluster *cluster.Cluster) error {
 
 	defer runJobMethod.RecordLatency(time.Now(), command.Name, cluster.Name)
-
 	runJobMethod.CountRequest(command.Name, cluster.Name)
 
 	// let's set environment


### PR DESCRIPTION
## Background
We are adding metrics to heimdall to enhance observability. This PR adds metrics over `jobs` to get the latency and the counts of requests, errors and successes.

## Changes
Add latency, request, error, success count over jobs per 
a. overall, 
b. cluster, 
c. command, 
d. cluster-command pair.
in [internal/pkg/heimdall/job.go](https://github.com/patterninc/heimdall/compare/alephys26/add_metrics?expand=1#diff-4383e8d8faae93d67c3bc6bceacb0daaacd15ad4e51aa1cda2b0db759110b366).

## Tests
The generated metrics are tested by spinning a local instance and all the metrics are indeed present.
<img width="699" height="841" alt="image" src="https://github.com/user-attachments/assets/40487499-983d-474d-a2eb-709d1a1223c1" />
