### PR TITLE
Add support for additional job arguments in Spark EKS job context for chipmunk jobs

### DIFF
--- a/internal/pkg/object/command/sparkeks/sparkeks.go
+++ b/internal/pkg/object/command/sparkeks/sparkeks.go
@@ -106,6 +106,7 @@ type sparkEksJobContext struct {
 	Query        string                 `yaml:"query,omitempty" json:"query,omitempty"`
 	Parameters   *sparkEksJobParameters `yaml:"parameters,omitempty" json:"parameters,omitempty"`
 	ReturnResult bool                   `yaml:"return_result,omitempty" json:"return_result,omitempty"`
+	Arguments    []string               `yaml:"arguments,omitempty" json:"arguments,omitempty"`
 }
 
 type sparkEksClusterContext struct {
@@ -599,6 +600,10 @@ func applySparkOperatorConfig(execCtx *executionContext) {
 		mainAppFile := s3aWrapperURI
 		if jobContext.ReturnResult {
 			sparkApp.Spec.Arguments = []string{execCtx.appName, s3aQueryURI, execCtx.job.User, s3aResultURI}
+		} else if len(jobContext.Arguments) > 0 {
+			args := []string{execCtx.appName, execCtx.job.User}
+			args = append(args, jobContext.Arguments...)
+			sparkApp.Spec.Arguments = args
 		} else {
 			sparkApp.Spec.Arguments = []string{execCtx.appName, s3aQueryURI, execCtx.job.User}
 		}


### PR DESCRIPTION
This pull request introduces support for passing custom arguments to Spark EKS jobs, enhancing flexibility in job configuration. The changes allow users to specify additional arguments that will be included when the job is executed, in addition to the existing parameter options.

Enhancement to Spark EKS job configuration:

* Added an `Arguments` field to the `sparkEksJobContext` struct, allowing users to specify a slice of custom arguments for Spark jobs.
* Updated the `applySparkOperatorConfig` function to use the new `Arguments` field: if `ReturnResult` is false and `Arguments` are provided, the job's argument list is constructed using the app name, user, and the custom arguments.