### PR TITLE
Update code for column types Decimal

### DIFF
--- a/internal/pkg/object/command/clickhouse/column_types.go
+++ b/internal/pkg/object/command/clickhouse/column_types.go
@@ -18,26 +18,6 @@ func (d *Decimal) Scan(value interface{}) error {
 		return nil
 	}
 	switch v := value.(type) {
-
-	case float32:
-		*d.d = decimal.NewFromFloat(float64(v))
-		return nil
-
-	case float64:
-		// numeric in sqlite3 sends us float64
-		*d.d = decimal.NewFromFloat(v)
-		return nil
-
-	case int64:
-		// at least in sqlite3 when the value is 0 in db, the data is sent
-		// to us as an int64 instead of a float64 ...
-		*d.d = decimal.New(v, 0)
-		return nil
-
-	case uint64:
-		// while clickhouse may send 0 in db as uint64
-		*d.d = decimal.NewFromUint64(v)
-		return nil
 	case decimal.Decimal:
 		if d.d == nil {
 			d.d = new(decimal.Decimal)


### PR DESCRIPTION
It appeared that github.com/shopspring/decimal can't be used when a Decimal can be nullable. The major reason for that NullDecimal can scan value which has a type Decimal
<img width="741" height="603" alt="image" src="https://github.com/user-attachments/assets/18f2235c-d000-462d-86d5-d9d763e36e12" />

That is why we have to update it 