### PR TITLE
Add EventLogURI to commandContext and update Spark event log directory handling

### DIFF
--- a/internal/pkg/object/command/sparkeks/sparkeks.go
+++ b/internal/pkg/object/command/sparkeks/sparkeks.go
@@ -94,6 +94,7 @@ var (
 type commandContext struct {
 	JobsURI       string            `yaml:"jobs_uri,omitempty" json:"jobs_uri,omitempty"`
 	WrapperURI    string            `yaml:"wrapper_uri,omitempty" json:"wrapper_uri,omitempty"`
+	EventLogURI   string            `yaml:"event_log_uri,omitempty" json:"event_log_uri,omitempty"`
 	Properties    map[string]string `yaml:"properties,omitempty" json:"properties,omitempty"`
 	KubeNamespace string            `yaml:"kube_namespace,omitempty" json:"kube_namespace,omitempty"`
 }
@@ -670,9 +671,10 @@ func applySparkOperatorConfig(execCtx *executionContext) {
 	// Add default spark properties
 	sparkApp.Spec.SparkConf[sparkAppNameProperty] = execCtx.appName
 
-	if execCtx.logURI != "" {
-		logURI := updateS3ToS3aURI(execCtx.logURI)
-		sparkApp.Spec.SparkConf[sparkEventLogDirProperty] = logURI
+	// Set spark event log directory for spark history server 
+	if execCtx.commandContext.EventLogURI != "" {
+		eventLogURI := updateS3ToS3aURI(execCtx.commandContext.EventLogURI)
+		sparkApp.Spec.SparkConf[sparkEventLogDirProperty] = eventLogURI
 	}
 
 	if sparkSubmitParams := getSparkSubmitParameters(jobContext); sparkSubmitParams != nil {


### PR DESCRIPTION
**Description**:
Currently we put all spark job logs inside separate directories for respective `{job_id}` due to this Spark History Server does not able to read event logs and it requires all the logs consolidated into single directory in order to render all the spark applications.

This pull request updates how the Spark event log directory is configured for Spark History Server in the `sparkeks` command implementation. The main change is to use the new `EventLogURI` field in the `commandContext` struct instead of the previous `logURI` field.

Configuration improvements:

* Added `EventLogURI` field to the `commandContext` struct to explicitly specify the event log URI for Spark jobs.
* Updated logic in `applySparkOperatorConfig` to use `commandContext.EventLogURI` for setting the Spark event log directory, replacing the previous use of `logURI`.