### PR TITLE
spark clustername fix

### DIFF
--- a/internal/pkg/object/command/sparkeks/sparkeks.go
+++ b/internal/pkg/object/command/sparkeks/sparkeks.go
@@ -114,6 +114,7 @@ type clusterContext struct {
 	Properties                 map[string]string `yaml:"properties,omitempty" json:"properties,omitempty"`
 	Image                      *string           `yaml:"image,omitempty" json:"image,omitempty"`
 	Region                     *string           `yaml:"region,omitempty" json:"region,omitempty"`
+	ClusterName                *string           `yaml:"cluster_name,omitempty" json:"cluster_name,omitempty"`
 	SparkApplicationFile       string            `yaml:"spark_application_file,omitempty" json:"spark_application_file,omitempty"`
 	RequiredSparkSQLExtensions string            `yaml:"required_spark_sql_extensions,omitempty" json:"required_spark_sql_extensions,omitempty"`
 }
@@ -513,7 +514,7 @@ func getAndUploadPodContainerLogs(ctx context.Context, execCtx *executionContext
 }
 
 // getSparkApplicationPodLogs fetches logs from pods and uploads them to S3.
-func getSparkApplicationPodLogs(ctx context.Context, execCtx *executionContext, pods []corev1.Pod, writeToStderr bool) error {
+func getSparkApplicationPodLogs(ctx context.Context, execCtx *executionContext, pods []corev1.Pod, writeToStderr bool) {
 	for _, pod := range pods {
 		if !isPodInValidPhase(pod) {
 			continue
@@ -525,7 +526,6 @@ func getSparkApplicationPodLogs(ctx context.Context, execCtx *executionContext, 
 			getAndUploadPodContainerLogs(ctx, execCtx, pod, container, true, stderrLogSuffix, false)
 		}
 	}
-	return nil
 }
 
 // createSparkClients creates Kubernetes and Spark clients for the EKS cluster.
@@ -563,7 +563,11 @@ func createSparkClients(ctx context.Context, execCtx *executionContext) error {
 	execCtx.kubeClient = kubeClient
 
 	if execCtx.runtime != nil && execCtx.runtime.Stdout != nil {
-		execCtx.runtime.Stdout.WriteString(fmt.Sprintf("Successfully created Spark Operator and Kubernetes clients for cluster: %s\n", execCtx.cluster.Name))
+		clusterName := ""
+		if execCtx.clusterContext.ClusterName != nil {
+			clusterName = *execCtx.clusterContext.ClusterName
+		}
+		execCtx.runtime.Stdout.WriteString(fmt.Sprintf("Successfully created Spark Operator and Kubernetes clients for cluster: %s\n", clusterName))
 	}
 	return nil
 }
@@ -590,10 +594,15 @@ func updateKubeConfig(ctx context.Context, execCtx *executionContext) (string, e
 	kubeconfigPath := tmpfile.Name()
 	tmpfile.Close() // Close the file so `aws` can write to it
 
+	clusterName := ""
+	if execCtx.clusterContext.ClusterName != nil {
+		clusterName = *execCtx.clusterContext.ClusterName
+	}
+
 	args := []string{
 		"eks", "update-kubeconfig",
 		"--region", region,
-		"--name", execCtx.cluster.Name,
+		"--name", clusterName,
 		"--kubeconfig", kubeconfigPath,
 	}
 	if roleArn != "" {
@@ -671,7 +680,7 @@ func applySparkOperatorConfig(execCtx *executionContext) {
 	// Add default spark properties
 	sparkApp.Spec.SparkConf[sparkAppNameProperty] = execCtx.appName
 
-	// Set spark event log directory for spark history server 
+	// Set spark event log directory for spark history server
 	if execCtx.commandContext.EventLogURI != "" {
 		eventLogURI := updateS3ToS3aURI(execCtx.commandContext.EventLogURI)
 		sparkApp.Spec.SparkConf[sparkEventLogDirProperty] = eventLogURI
@@ -902,9 +911,7 @@ func collectSparkApplicationLogs(ctx context.Context, execCtx *executionContext,
 		return
 	}
 
-	if err := getSparkApplicationPodLogs(ctx, execCtx, pods, writeToStderr); err != nil {
-		execCtx.runtime.Stderr.WriteString(fmt.Sprintf("Warning: failed to collect pod logs: %v\n", err))
-	}
+	getSparkApplicationPodLogs(ctx, execCtx, pods, writeToStderr)
 }
 
 // isTerminalState checks if the given state is a terminal state.

--- a/internal/pkg/object/command/sparkeks/sparkeks.go
+++ b/internal/pkg/object/command/sparkeks/sparkeks.go
@@ -114,7 +114,7 @@ type clusterContext struct {
 	Properties                 map[string]string `yaml:"properties,omitempty" json:"properties,omitempty"`
 	Image                      *string           `yaml:"image,omitempty" json:"image,omitempty"`
 	Region                     *string           `yaml:"region,omitempty" json:"region,omitempty"`
-	ClusterName                *string           `yaml:"cluster_name,omitempty" json:"cluster_name,omitempty"`
+	KubernetesClusterName      *string           `yaml:"cluster_name,omitempty" json:"cluster_name,omitempty"`
 	SparkApplicationFile       string            `yaml:"spark_application_file,omitempty" json:"spark_application_file,omitempty"`
 	RequiredSparkSQLExtensions string            `yaml:"required_spark_sql_extensions,omitempty" json:"required_spark_sql_extensions,omitempty"`
 }
@@ -565,8 +565,8 @@ func createSparkClients(ctx context.Context, execCtx *executionContext) error {
 
 	if execCtx.runtime != nil && execCtx.runtime.Stdout != nil {
 		clusterName := ""
-		if execCtx.clusterContext.ClusterName != nil {
-			clusterName = *execCtx.clusterContext.ClusterName
+		if execCtx.clusterContext.KubernetesClusterName != nil {
+			clusterName = *execCtx.clusterContext.KubernetesClusterName
 		}
 		execCtx.runtime.Stdout.WriteString(fmt.Sprintf("Successfully created Spark Operator and Kubernetes clients for cluster: %s\n", clusterName))
 	}
@@ -596,8 +596,8 @@ func updateKubeConfig(ctx context.Context, execCtx *executionContext) (string, e
 	tmpfile.Close() // Close the file so `aws` can write to it
 
 	clusterName := ""
-	if execCtx.clusterContext.ClusterName != nil {
-		clusterName = *execCtx.clusterContext.ClusterName
+	if execCtx.clusterContext.KubernetesClusterName != nil {
+		clusterName = *execCtx.clusterContext.KubernetesClusterName
 	}
 
 	args := []string{

--- a/internal/pkg/object/command/sparkeks/sparkeks.go
+++ b/internal/pkg/object/command/sparkeks/sparkeks.go
@@ -514,7 +514,7 @@ func getAndUploadPodContainerLogs(ctx context.Context, execCtx *executionContext
 }
 
 // getSparkApplicationPodLogs fetches logs from pods and uploads them to S3.
-func getSparkApplicationPodLogs(ctx context.Context, execCtx *executionContext, pods []corev1.Pod, writeToStderr bool) {
+func getSparkApplicationPodLogs(ctx context.Context, execCtx *executionContext, pods []corev1.Pod, writeToStderr bool) error {
 	for _, pod := range pods {
 		if !isPodInValidPhase(pod) {
 			continue
@@ -526,6 +526,7 @@ func getSparkApplicationPodLogs(ctx context.Context, execCtx *executionContext, 
 			getAndUploadPodContainerLogs(ctx, execCtx, pod, container, true, stderrLogSuffix, false)
 		}
 	}
+	return nil
 }
 
 // createSparkClients creates Kubernetes and Spark clients for the EKS cluster.
@@ -911,7 +912,9 @@ func collectSparkApplicationLogs(ctx context.Context, execCtx *executionContext,
 		return
 	}
 
-	getSparkApplicationPodLogs(ctx, execCtx, pods, writeToStderr)
+	if err := getSparkApplicationPodLogs(ctx, execCtx, pods, writeToStderr); err != nil {
+		execCtx.runtime.Stderr.WriteString(fmt.Sprintf("Warning: failed to collect pod logs: %v\n", err))
+	}
 }
 
 // isTerminalState checks if the given state is a terminal state.


### PR DESCRIPTION
This pull request introduces support for an explicit `ClusterName` field in the `clusterContext` struct within the Spark EKS command implementation. The main changes ensure that the cluster name is consistently sourced from this new field, improving clarity and flexibility when managing clusters.

Cluster context and configuration improvements:

* Added a new `ClusterName` field to the `clusterContext` struct to explicitly store the cluster's name.
* Updated the `updateKubeConfig` function to use the new `ClusterName` field when setting the EKS cluster name in AWS CLI arguments, replacing the previous usage of `execCtx.cluster.Name`.
* Modified the `createSparkClients` function to use the new `ClusterName` field when printing success messages about client creation, ensuring consistent and accurate cluster identification.