### PR TITLE
FEAT: Pagination support for /jobs endpoint

### DIFF
--- a/internal/pkg/heimdall/job_dal.go
+++ b/internal/pkg/heimdall/job_dal.go
@@ -223,13 +223,11 @@ func (h *Heimdall) getJob(ctx context.Context, j *jobRequest) (any, error) {
 
 }
 
-const (
-	defaultPageSize = 101
-	maxPageSize     = 1000
-)
+const defaultPageSize = 101
 
 func (h *Heimdall) getJobs(ctx context.Context, f *database.Filter) (any, error) {
 
+	// Track DB connection for jobs list operation
 	defer getJobsMethod.RecordLatency(time.Now())
 	getJobsMethod.CountRequest()
 
@@ -237,14 +235,15 @@ func (h *Heimdall) getJobs(ctx context.Context, f *database.Filter) (any, error)
 	pageSize := defaultPageSize
 	if v, ok := (*f)[`limit`]; ok {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			if n > maxPageSize {
-				n = maxPageSize
+			if n > defaultPageSize {
+				n = defaultPageSize
 			}
 			pageSize = n
 		}
 		delete(*f, `limit`)
 	}
 
+	// open connection
 	sess, err := h.Database.NewSession(false)
 	if err != nil {
 		getJobsMethod.LogAndCountError(err, "new_session")

--- a/internal/pkg/heimdall/job_dal.go
+++ b/internal/pkg/heimdall/job_dal.go
@@ -6,6 +6,8 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hladush/go-telemetry/pkg/telemetry"
@@ -87,6 +89,9 @@ var (
 				Item:    `$%d`,
 				Join:    `, `,
 				Value:   `js.job_status_name in ({{ .Slice }})`,
+			},
+			`cursor`: {
+				Value: `j.system_job_id < $%d`,
 			},
 		},
 	}
@@ -218,13 +223,28 @@ func (h *Heimdall) getJob(ctx context.Context, j *jobRequest) (any, error) {
 
 }
 
+const (
+	defaultPageSize = 101
+	maxPageSize     = 1000
+)
+
 func (h *Heimdall) getJobs(ctx context.Context, f *database.Filter) (any, error) {
 
-	// Track DB connection for jobs list operation
 	defer getJobsMethod.RecordLatency(time.Now())
 	getJobsMethod.CountRequest()
 
-	// open connection
+	// extract limit before rendering WHERE clause (it is not a filter condition)
+	pageSize := defaultPageSize
+	if v, ok := (*f)[`limit`]; ok {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			if n > maxPageSize {
+				n = maxPageSize
+			}
+			pageSize = n
+		}
+		delete(*f, `limit`)
+	}
+
 	sess, err := h.Database.NewSession(false)
 	if err != nil {
 		getJobsMethod.LogAndCountError(err, "new_session")
@@ -238,6 +258,10 @@ func (h *Heimdall) getJobs(ctx context.Context, f *database.Filter) (any, error)
 		return nil, err
 	}
 
+	// append LIMIT; fetch one extra row to detect whether a next page exists
+	query = fmt.Sprintf("%s\nlimit $%d", strings.TrimRight(query, "\n; \t"), len(args)+1)
+	args = append(args, pageSize+1)
+
 	rows, err := sess.Query(query, args...)
 	if err != nil {
 		getJobsMethod.LogAndCountError(err, "query")
@@ -245,7 +269,7 @@ func (h *Heimdall) getJobs(ctx context.Context, f *database.Filter) (any, error)
 	}
 	defer rows.Close()
 
-	result := make([]*job.Job, 0, 100)
+	result := make([]*job.Job, 0, pageSize+1)
 
 	for rows.Next() {
 
@@ -267,10 +291,15 @@ func (h *Heimdall) getJobs(ctx context.Context, f *database.Filter) (any, error)
 
 	}
 
+	rs := &resultset{Data: result}
+	if len(result) > pageSize {
+		rs.HasMore = true
+		rs.NextCursor = result[pageSize-1].SystemID
+		rs.Data = result[:pageSize]
+	}
+
 	getJobsMethod.CountSuccess()
-	return &resultset{
-		Data: result,
-	}, nil
+	return rs, nil
 
 }
 

--- a/internal/pkg/heimdall/job_dal.go
+++ b/internal/pkg/heimdall/job_dal.go
@@ -95,6 +95,11 @@ var (
 			},
 		},
 	}
+
+	// tag filters use correlated EXISTS — one clause per value, all must match (AND semantics)
+	jobsTagsFilterConfig = map[string]string{
+		`tags`: `exists (select 1 from job_tags jt where jt.system_job_id = j.system_job_id and jt.job_tag = $%d)`,
+	}
 )
 
 type jobRequest struct {
@@ -225,6 +230,35 @@ func (h *Heimdall) getJob(ctx context.Context, j *jobRequest) (any, error) {
 
 const defaultPageSize = 101
 
+func injectTagsFilter(f *database.Filter, key, existsTemplate string, query string, args []any) (string, []any) {
+	v, ok := (*f)[key]
+	if !ok {
+		return query, args
+	}
+	delete(*f, key)
+
+	var clauses []string
+	for _, t := range strings.Split(v, `,`) {
+		if t = strings.TrimSpace(t); t != `` {
+			clauses = append(clauses, fmt.Sprintf(existsTemplate, len(args)+1))
+			args = append(args, t)
+		}
+	}
+	if len(clauses) == 0 {
+		return query, args
+	}
+
+	idx := strings.Index(query, "\norder by")
+	if idx < 0 {
+		return query, args
+	}
+	before, after, clause := query[:idx], query[idx:], strings.Join(clauses, " and\n    ")
+	if strings.Contains(before, "where") {
+		return before + " and\n    " + clause + after, args
+	}
+	return before + "\nwhere\n    " + clause + after, args
+}
+
 func (h *Heimdall) getJobs(ctx context.Context, f *database.Filter) (any, error) {
 
 	// Track DB connection for jobs list operation
@@ -255,6 +289,10 @@ func (h *Heimdall) getJobs(ctx context.Context, f *database.Filter) (any, error)
 	if err != nil {
 		getJobsMethod.LogAndCountError(err, "query")
 		return nil, err
+	}
+
+	for key, tmpl := range jobsTagsFilterConfig {
+		query, args = injectTagsFilter(f, key, tmpl, query, args)
 	}
 
 	// append LIMIT; fetch one extra row to detect whether a next page exists

--- a/internal/pkg/heimdall/queries/job/select_jobs.sql
+++ b/internal/pkg/heimdall/queries/job/select_jobs.sql
@@ -26,6 +26,3 @@ where
     {{ .Clause }}{{end}}
 order by
     j.system_job_id desc
-limit
-    101
-;

--- a/internal/pkg/heimdall/result.go
+++ b/internal/pkg/heimdall/result.go
@@ -1,5 +1,7 @@
 package heimdall
 
 type resultset struct {
-	Data any `yaml:"data,omitempty" json:"data,omitempty"`
+	Data       any   `json:"data,omitempty"`
+	HasMore    bool  `json:"has_more,omitempty"`
+	NextCursor int64 `json:"next_cursor,omitempty"`
 }


### PR DESCRIPTION
**Description**
This pull request adds cursor-based pagination to the jobs listing endpoint in the Heimdall package. The main changes include extracting and enforcing page size limits, updating the SQL query to support cursor and limit parameters, and modifying the result set to indicate if more results are available and provide a cursor for the next page.

**Pagination and query improvements:**

* Added support for a `cursor` filter and removed the hardcoded SQL `LIMIT` in `select_jobs.sql`, enabling dynamic pagination through the API (`internal/pkg/heimdall/job_dal.go`, `internal/pkg/heimdall/queries/job/select_jobs.sql`). [[1]](diffhunk://#diff-b25474ab05c01538edc7cabf85d248c260bddd5cb085f4a1e5bf43bc9156d9ebR93-R95) [[2]](diffhunk://#diff-bb10879b031bb1f9a776da933fd1ad3f6486eab08b8f09d7cdcc59a319ccde5aL29-L31)
* Extracted and enforced page size limits (`defaultPageSize` and `maxPageSize`), and updated the query to fetch one extra row to determine if more results exist (`internal/pkg/heimdall/job_dal.go`). [[1]](diffhunk://#diff-b25474ab05c01538edc7cabf85d248c260bddd5cb085f4a1e5bf43bc9156d9ebR226-R247) [[2]](diffhunk://#diff-b25474ab05c01538edc7cabf85d248c260bddd5cb085f4a1e5bf43bc9156d9ebR261-R272)
*Added support for filtering using comma seperated tag values
e.g.:
```
http://127.0.0.1:9090/api/v1/jobs?name=run-my-query&tags=_name:run-my-query3,_id:fa9af168-b328-4ef3-a1b1-1a9ffbaf60fd
```
**Result structure changes:**

* Modified the `resultset` struct to include `HasMore` and `NextCursor` fields, and updated the handler to populate these fields based on the query results (`internal/pkg/heimdall/result.go`, `internal/pkg/heimdall/job_dal.go`). [[1]](diffhunk://#diff-32e0115227cf178b9b8a9b1007729a34681c01240c1b55e34d46ad344161f8abL4-R6) [[2]](diffhunk://#diff-b25474ab05c01538edc7cabf85d248c260bddd5cb085f4a1e5bf43bc9156d9ebR294-R302)

**Dependency updates:**

* Imported `strconv` and `strings` to support parsing and manipulating filter parameters and queries (`internal/pkg/heimdall/job_dal.go`).

Testing:

```
curl --location --request GET 'http://127.0.0.1:9090/api/v1/jobs?limit=5' 
```
Result : Gives 5 objects in respone

```
curl --location --request GET 'http://127.0.0.1:9090/api/v1/jobs'
```
Result : Default page size(101) or present number of jobs, whichever is lower along with     
    "has_more": true/false (depending on values available)
    "next_cursor": 112

```
curl --location --request GET 'http://127.0.0.1:9090/api/v1/jobs?limit=5&cursor=5
```
Result : Gives 5 objects ordered by system_job_id, and ahead of cursor specified


```
curl --location --request GET 'http://127.0.0.1:9090/api/v1/jobs?limit=5&cursor=5&tags=_name:run-my-query3,_id:fa9af168-b328-4ef3-a1b1-1a9ffbaf60fd
```
Result : Gives 5 objects ordered by system_job_id, and ahead of cursor specified with exact match for both tags