### PR TITLE
feat(ecs): support assign_public_ip in vpc_config for public Fargate clusters

### DIFF
--- a/internal/pkg/object/command/ecs/ecs.go
+++ b/internal/pkg/object/command/ecs/ecs.go
@@ -57,6 +57,7 @@ type clusterContext struct {
 type vpcConfig struct {
 	Subnets        []string `yaml:"subnets,omitempty" json:"subnets,omitempty"`
 	SecurityGroups []string `yaml:"security_groups,omitempty" json:"security_groups,omitempty"`
+	AssignPublicIp bool     `yaml:"assign_public_ip,omitempty" json:"assign_public_ip,omitempty"`
 }
 
 // Task definition wrapper with pre-computed essential containers map
@@ -649,7 +650,7 @@ func runTask(ctx context.Context, execCtx *executionContext, startedBy string, t
 			AwsvpcConfiguration: &types.AwsVpcConfiguration{
 				Subnets:        execCtx.ClusterConfig.VPCConfig.Subnets,
 				SecurityGroups: execCtx.ClusterConfig.VPCConfig.SecurityGroups,
-				AssignPublicIp: types.AssignPublicIpDisabled,
+				AssignPublicIp: assignPublicIp(execCtx.ClusterConfig.VPCConfig.AssignPublicIp),
 			},
 		},
 	}
@@ -839,6 +840,14 @@ func retryWithBackoff(ctx context.Context, maxRetries int, op func() error) erro
 		}
 	}
 	return err
+}
+
+// assignPublicIp converts a bool to the ECS AssignPublicIp enum value.
+func assignPublicIp(enabled bool) types.AssignPublicIp {
+	if enabled {
+		return types.AssignPublicIpEnabled
+	}
+	return types.AssignPublicIpDisabled
 }
 
 // isThrottlingError reports whether err is an AWS throttling error.


### PR DESCRIPTION
## Summary
- Adds `assign_public_ip` boolean field to the `vpcConfig` struct in the ECS plugin
- When `true`, tasks are launched with `AssignPublicIp: ENABLED`; defaults to `DISABLED` (no behavior change for existing clusters)
- Enables running Fargate tasks in public subnets without a NAT gateway

## Test plan
- [x] Verify existing private-subnet clusters (e.g. `ecs-fargate-0.0.1`) still work with no config change
- [x] Deploy a test job against the new `ecs-fargate-public-0.0.1` cluster in heimdall-config and confirm the task gets a public IP and can pull the ECR image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Test Results: 
- Successfully ran an ECS Fargate job in a public subnet using the public cluster configuration 
<img width="598" height="463" alt="Screenshot 2026-05-26 at 10 34 58 AM" src="https://github.com/user-attachments/assets/ca0bec3f-0ca7-43b5-b6d0-a708849e0190" />


Sample ECS Fargate Cluster Config: 

```  
- name: ecs-fargate-public-0.0.1
    status: active
    version: 0.0.1
    description: AWS Fargate cluster using public subnets with public IPs (no NAT required)
    tags:
      - type:fargate
      - type:fargate-public
    context:
      max_cpu: 4096
      max_memory: 8192
      max_task_count: 30
      execution_role_arn: arn:aws:iam::myexecutionrole
      task_role_arn: arn:aws:iam::myrole
      cluster_name: prod-data-platform-1
      launch_type: FARGATE
      vpc_config:
        subnets:
          - subnet-id-1
          - subnet-id-2
          - subnet-id-3
          - subnet-id-4
        security_groups:
          - sg-0
        assign_public_ip: true
```
