### PR TITLE
feat: command caller specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Heimdall removes the need for:
 
 It centralizes execution logic, logging, and auditing—all accessible via API or UI.
 
+Commands may also restrict invocation via `allowed_callers` — a list of anchored regex patterns matched against `X-Heimdall-User`. Omitted/empty means open; non-matching callers are rejected at submit.
+
 ---
 
 ## 📦 API Overview

--- a/internal/pkg/heimdall/handler.go
+++ b/internal/pkg/heimdall/handler.go
@@ -3,6 +3,7 @@ package heimdall
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -45,8 +46,19 @@ func writeAPIError(w http.ResponseWriter, err error, obj any) {
 	responseJSON, _ := json.Marshal(response)
 
 	w.Header().Add(contentTypeKey, contentTypeJSON)
-	w.WriteHeader(http.StatusInternalServerError)
+	w.WriteHeader(statusForError(err))
 	w.Write(responseJSON)
+}
+
+func statusForError(err error) int {
+	switch {
+	case errors.Is(err, ErrCallerNotAllowed):
+		return http.StatusForbidden
+	case errors.Is(err, ErrNoCaller):
+		return http.StatusUnauthorized
+	default:
+		return http.StatusInternalServerError
+	}
 }
 
 func payloadHandler[T any](fn func(context.Context, *T) (any, error)) http.HandlerFunc {

--- a/internal/pkg/heimdall/job.go
+++ b/internal/pkg/heimdall/job.go
@@ -39,6 +39,7 @@ const (
 var (
 	ErrCommandClusterPairNotFound = fmt.Errorf(`command-cluster pair is not found`)
 	ErrJobCancelFailed            = fmt.Errorf(`async job unrecognized or already in final state`)
+	ErrCallerNotAllowed           = fmt.Errorf(`caller is not allowed to run this command`)
 	runJobMethod                  = telemetry.NewMethod("runJob", "heimdall")
 	cancelJobMethod               = telemetry.NewMethod("db_connection", "cancel_job")
 )
@@ -62,6 +63,11 @@ func (h *Heimdall) submitJob(ctx context.Context, j *job.Job) (any, error) {
 	command, cluster, err := h.resolveJob(j.CommandCriteria, j.ClusterCriteria)
 	if err != nil {
 		return j, err
+	}
+
+	// enforce per-command caller allowlist
+	if !command.IsCallerAllowed(j.User) {
+		return j, ErrCallerNotAllowed
 	}
 
 	// let's set the mode in which we'll execute our job

--- a/pkg/object/command/command.go
+++ b/pkg/object/command/command.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/babourine/x/pkg/set"
 
@@ -86,11 +87,15 @@ func (c *Command) IsCallerAllowed(user string) bool {
 }
 
 func (c *Command) setCallerPatterns() error {
+	c.callerPatterns = nil
 	if c.AllowedCallers == nil || c.AllowedCallers.Len() == 0 {
 		return nil
 	}
 	patterns := make([]*regexp.Regexp, 0, c.AllowedCallers.Len())
 	for _, raw := range c.AllowedCallers.Slice() {
+		if strings.TrimSpace(raw) == `` {
+			return fmt.Errorf("command %s: allowed_callers contains empty pattern", c.ID)
+		}
 		re, err := regexp.Compile(`^(?:` + raw + `)$`)
 		if err != nil {
 			return fmt.Errorf("command %s: invalid allowed_callers pattern %q: %w", c.ID, raw, err)

--- a/pkg/object/command/command.go
+++ b/pkg/object/command/command.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/babourine/x/pkg/set"
 
@@ -15,12 +16,14 @@ var (
 )
 
 type Command struct {
-	object.Object `yaml:",inline" json:",inline"`
-	Status        status.Status    `yaml:"status,omitempty" json:"status,omitempty"`
-	Plugin        string           `yaml:"plugin,omitempty" json:"plugin,omitempty"`
-	IsSync        bool             `yaml:"is_sync,omitempty" json:"is_sync,omitempty"`
-	ClusterTags   *set.Set[string] `yaml:"cluster_tags,omitempty" json:"cluster_tags,omitempty"`
-	Handler       plugin.Handler   `yaml:"-" json:"-"`
+	object.Object  `yaml:",inline" json:",inline"`
+	Status         status.Status    `yaml:"status,omitempty" json:"status,omitempty"`
+	Plugin         string           `yaml:"plugin,omitempty" json:"plugin,omitempty"`
+	IsSync         bool             `yaml:"is_sync,omitempty" json:"is_sync,omitempty"`
+	ClusterTags    *set.Set[string] `yaml:"cluster_tags,omitempty" json:"cluster_tags,omitempty"`
+	AllowedCallers *set.Set[string] `yaml:"allowed_callers,omitempty" json:"allowed_callers,omitempty"`
+	Handler        plugin.Handler   `yaml:"-" json:"-"`
+	callerPatterns []*regexp.Regexp `yaml:"-" json:"-"`
 }
 
 type Commands map[string]*Command
@@ -62,6 +65,38 @@ func (c *Command) Init() error {
 		c.Status = status.Active
 	}
 
+	if err := c.setCallerPatterns(); err != nil {
+		return err
+	}
+
 	return nil
 
+}
+
+func (c *Command) IsCallerAllowed(user string) bool {
+	if len(c.callerPatterns) == 0 {
+		return true
+	}
+	for _, re := range c.callerPatterns {
+		if re.MatchString(user) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Command) setCallerPatterns() error {
+	if c.AllowedCallers == nil || c.AllowedCallers.Len() == 0 {
+		return nil
+	}
+	patterns := make([]*regexp.Regexp, 0, c.AllowedCallers.Len())
+	for _, raw := range c.AllowedCallers.Slice() {
+		re, err := regexp.Compile(`^(?:` + raw + `)$`)
+		if err != nil {
+			return fmt.Errorf("command %s: invalid allowed_callers pattern %q: %w", c.ID, raw, err)
+		}
+		patterns = append(patterns, re)
+	}
+	c.callerPatterns = patterns
+	return nil
 }

--- a/pkg/object/command/command.go
+++ b/pkg/object/command/command.go
@@ -24,7 +24,7 @@ type Command struct {
 	ClusterTags    *set.Set[string] `yaml:"cluster_tags,omitempty" json:"cluster_tags,omitempty"`
 	AllowedCallers *set.Set[string] `yaml:"allowed_callers,omitempty" json:"allowed_callers,omitempty"`
 	Handler        plugin.Handler   `yaml:"-" json:"-"`
-	callerPatterns []*regexp.Regexp `yaml:"-" json:"-"`
+	callerPattern  *regexp.Regexp   `yaml:"-" json:"-"`
 }
 
 type Commands map[string]*Command
@@ -75,33 +75,31 @@ func (c *Command) Init() error {
 }
 
 func (c *Command) IsCallerAllowed(user string) bool {
-	if len(c.callerPatterns) == 0 {
+	if c.callerPattern == nil {
 		return true
 	}
-	for _, re := range c.callerPatterns {
-		if re.MatchString(user) {
-			return true
-		}
-	}
-	return false
+	return c.callerPattern.MatchString(user)
 }
 
 func (c *Command) setCallerPatterns() error {
-	c.callerPatterns = nil
+	c.callerPattern = nil
 	if c.AllowedCallers == nil || c.AllowedCallers.Len() == 0 {
 		return nil
 	}
-	patterns := make([]*regexp.Regexp, 0, c.AllowedCallers.Len())
+	parts := make([]string, 0, c.AllowedCallers.Len())
 	for _, raw := range c.AllowedCallers.Slice() {
 		if strings.TrimSpace(raw) == `` {
 			return fmt.Errorf("command %s: allowed_callers contains empty pattern", c.ID)
 		}
-		re, err := regexp.Compile(`^(?:` + raw + `)$`)
-		if err != nil {
+		if _, err := regexp.Compile(raw); err != nil {
 			return fmt.Errorf("command %s: invalid allowed_callers pattern %q: %w", c.ID, raw, err)
 		}
-		patterns = append(patterns, re)
+		parts = append(parts, `(?:`+raw+`)`)
 	}
-	c.callerPatterns = patterns
+	re, err := regexp.Compile(`^(?:` + strings.Join(parts, `|`) + `)$`)
+	if err != nil {
+		return fmt.Errorf("command %s: failed to compile combined allowed_callers regex: %w", c.ID, err)
+	}
+	c.callerPattern = re
 	return nil
 }


### PR DESCRIPTION
### Description
This pull request introduces support for per-command caller allowlists, enabling commands to restrict which users can invoke them based on anchored regex patterns. The implementation includes changes to both the command object and the job submission logic, along with an update to the documentation.

### Changes
**Command allowlist enforcement:**

* Added a new `AllowedCallers` field to the `Command` struct, allowing configuration of permitted callers as anchored regex patterns. Patterns are compiled and cached for efficient matching. (`pkg/object/command/command.go`, [[1]](diffhunk://#diff-b9b3486fd7b08c1e9d4114aa01ce0ff63ca6f5b2ade0c8278c80bfbf636ad8c8R24-R26) [[2]](diffhunk://#diff-b9b3486fd7b08c1e9d4114aa01ce0ff63ca6f5b2ade0c8278c80bfbf636ad8c8R68-R102)
* Implemented the `IsCallerAllowed` method on the `Command` struct to check if a user matches any of the allowed caller patterns. (`pkg/object/command/command.go`, [pkg/object/command/command.goR68-R102](diffhunk://#diff-b9b3486fd7b08c1e9d4114aa01ce0ff63ca6f5b2ade0c8278c80bfbf636ad8c8R68-R102))
* During job submission, Heimdall now enforces the allowlist by rejecting jobs from disallowed callers with a specific error. (`internal/pkg/heimdall/job.go`, [[1]](diffhunk://#diff-4383e8d8faae93d67c3bc6bceacb0daaacd15ad4e51aa1cda2b0db759110b366R68-R72) [[2]](diffhunk://#diff-4383e8d8faae93d67c3bc6bceacb0daaacd15ad4e51aa1cda2b0db759110b366R42)

**Documentation:**

* Updated the `README.md` to describe the new `allowed_callers` feature and its effect on command invocation.

### Tests
Tested locally on docker compose and with unit tests. All passed.