### PR TITLE
feat(ecs): add AWS task tag support

### DIFF
--- a/internal/pkg/object/command/ecs/ecs.go
+++ b/internal/pkg/object/command/ecs/ecs.go
@@ -39,18 +39,20 @@ type commandContext struct {
 	PollingInterval        duration.Duration         `yaml:"polling_interval,omitempty" json:"polling_interval,omitempty"`
 	Timeout                duration.Duration         `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 	MaxFailCount           int                       `yaml:"max_fail_count,omitempty" json:"max_fail_count,omitempty"` // max failures before giving up
+	Tags                   map[string]string         `yaml:"tags,omitempty" json:"tags,omitempty"`
 }
 
 // ECS cluster context structure
 type clusterContext struct {
-	MaxCPU           int       `yaml:"max_cpu,omitempty" json:"max_cpu,omitempty"`
-	MaxMemory        int       `yaml:"max_memory,omitempty" json:"max_memory,omitempty"`
-	MaxTaskCount     int       `yaml:"max_task_count,omitempty" json:"max_task_count,omitempty"`
-	ExecutionRoleARN string    `yaml:"execution_role_arn,omitempty" json:"execution_role_arn,omitempty"`
-	TaskRoleARN      string    `yaml:"task_role_arn,omitempty" json:"task_role_arn,omitempty"`
-	ClusterName      string    `yaml:"cluster_name,omitempty" json:"cluster_name,omitempty"`
-	LaunchType       string    `yaml:"launch_type,omitempty" json:"launch_type,omitempty"`
-	VPCConfig        vpcConfig `yaml:"vpc_config,omitempty" json:"vpc_config,omitempty"`
+	MaxCPU           int               `yaml:"max_cpu,omitempty" json:"max_cpu,omitempty"`
+	MaxMemory        int               `yaml:"max_memory,omitempty" json:"max_memory,omitempty"`
+	MaxTaskCount     int               `yaml:"max_task_count,omitempty" json:"max_task_count,omitempty"`
+	ExecutionRoleARN string            `yaml:"execution_role_arn,omitempty" json:"execution_role_arn,omitempty"`
+	TaskRoleARN      string            `yaml:"task_role_arn,omitempty" json:"task_role_arn,omitempty"`
+	ClusterName      string            `yaml:"cluster_name,omitempty" json:"cluster_name,omitempty"`
+	LaunchType       string            `yaml:"launch_type,omitempty" json:"launch_type,omitempty"`
+	VPCConfig        vpcConfig         `yaml:"vpc_config,omitempty" json:"vpc_config,omitempty"`
+	Tags             map[string]string `yaml:"tags,omitempty" json:"tags,omitempty"`
 }
 
 // VPC configuration structure
@@ -102,6 +104,7 @@ type executionContext struct {
 	PollingInterval duration.Duration `json:"polling_interval"`
 	Timeout         duration.Duration `json:"timeout"`
 	MaxFailCount    int               `json:"max_fail_count"`
+	Tags            map[string]string `json:"tags,omitempty"`
 
 	runtime       *plugin.Runtime
 	ecsClient     *ecs.Client
@@ -461,6 +464,7 @@ func buildExecutionContext(ctx context.Context, commandCtx *commandContext, j *j
 	}
 
 	// Overlay job context (overrides command values)
+	// Note: json.Unmarshal merges map fields, so command tags are preserved and job tags overlay them
 	if j.Context != nil {
 		if err := j.Context.Unmarshal(execCtx); err != nil {
 			return nil, err
@@ -475,6 +479,10 @@ func buildExecutionContext(ctx context.Context, commandCtx *commandContext, j *j
 		}
 	}
 	execCtx.ClusterConfig = clusterContext
+
+	// Merge cluster tags as the base, with command+job tags (already merged by json.Unmarshal) taking precedence
+	execCtx.Tags = mergeMaps(clusterContext.Tags, execCtx.Tags)
+	execCtx.Tags["job_id"] = j.ID
 
 	// Load task definition template
 	taskDefWrapper, err := loadTaskDefinitionTemplate(commandCtx.TaskDefinitionTemplate)
@@ -653,6 +661,7 @@ func runTask(ctx context.Context, execCtx *executionContext, startedBy string, t
 				AssignPublicIp: assignPublicIp(execCtx.ClusterConfig.VPCConfig.AssignPublicIp),
 			},
 		},
+		Tags: toECSTags(execCtx.Tags),
 	}
 
 	var runTaskOutput *ecs.RunTaskOutput
@@ -848,6 +857,26 @@ func assignPublicIp(enabled bool) types.AssignPublicIp {
 		return types.AssignPublicIpEnabled
 	}
 	return types.AssignPublicIpDisabled
+}
+
+// mergeMaps merges multiple string maps into one. Later maps take precedence.
+func mergeMaps(maps ...map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for _, m := range maps {
+		for k, v := range m {
+			merged[k] = v
+		}
+	}
+	return merged
+}
+
+// toECSTags converts a map of string key-value pairs to ECS task tags.
+func toECSTags(tags map[string]string) []types.Tag {
+	result := make([]types.Tag, 0, len(tags))
+	for k, v := range tags {
+		result = append(result, types.Tag{Key: aws.String(k), Value: aws.String(v)})
+	}
+	return result
 }
 
 // isThrottlingError reports whether err is an AWS throttling error.

--- a/plugins/ecs/README.md
+++ b/plugins/ecs/README.md
@@ -34,6 +34,9 @@ An ECS command requires a task definition template and configuration for running
     polling_interval: "30s"  # 30 seconds
     timeout: "1h"            # 1 hour
     max_fail_count: 3        # max retries per task
+    tags:
+      env: prod
+      team: data-platform
   tags:
     - type:ecs
   cluster_tags:
@@ -76,9 +79,44 @@ ECS clusters must specify Fargate configuration, IAM roles, and network settings
         - subnet-87654321
       security_groups:
         - sg-12345678
+      tags:
+        cluster: my-fargate-cluster
+        env: prod
   tags:
     - type:fargate
     - data:prod
+```
+
+---
+
+## 🏷️ AWS Task Tags
+
+Tags are attached to every ECS task at launch and are useful for cost allocation, filtering, and auditing in the AWS console.
+
+### Tag Precedence
+
+Tags are merged from three sources, with later sources taking precedence:
+
+1. **Cluster context** — baseline tags applied to all tasks on the cluster
+2. **Command context** — tags applied to all jobs using this command
+3. **Job context** — per-job tags supplied at submission time
+
+### Automatic Tags
+
+The following tag is always added by Heimdall and cannot be overridden:
+
+| Tag | Value |
+|-----|-------|
+| `job_id` | The Heimdall job ID |
+
+### Example
+
+Given cluster tags `{env: prod}`, command tags `{team: data}`, and job tags `{env: staging}`, the resulting task tags will be:
+
+```
+env=staging   (job overrides cluster)
+team=data     (from command)
+job_id=abc123 (always added)
 ```
 
 ---
@@ -97,6 +135,10 @@ A typical ECS job includes task configuration and optional overrides:
     "task_count": 2,
     "cpu": 256,
     "memory": 512,
+    "tags": {
+      "pipeline": "my-pipeline",
+      "owner": "will"
+    },
     "container_overrides": [
       {
         "name": "main",
@@ -356,6 +398,9 @@ container_overrides:
     max_fail_count: 3
     cpu: 256
     memory: 512
+    tags:
+      env: prod
+      team: data-platform
   tags:
     - type:ecs
   cluster_tags:


### PR DESCRIPTION
## Summary

- Adds a `tags` field to the ECS cluster context, command context, and job context so operators can attach arbitrary AWS resource tags to tasks at launch
- Tags are merged in precedence order: **cluster < command < job**, so more specific contexts can override broader defaults
- `job_id` is always injected automatically so every ECS task is traceable back to its Heimdall job

## How it works

Tags from all three levels are resolved once in `buildExecutionContext` before any tasks are launched:
1. Cluster tags form the base
2. Command tags overlay cluster tags (`json.Unmarshal` merges map fields, so command and job tags are already merged by the time they reach the execution context)
3. `job_id` is set last and cannot be overridden

## Example config

```yaml
# Cluster context
tags:
  env: prod
  cluster: ecs-fargate

# Command context
tags:
  team: data-platform

# Job context (at submission time)
tags:
  pipeline: my-pipeline
```

Resulting ECS task tags: `env=prod`, `cluster=ecs-fargate`, `team=data-platform`, `pipeline=my-pipeline`, `job_id=<heimdall-job-id>`

## Test plan

- [x] Submit an ECS job and verify tags appear on the task in the AWS console
- [x] Confirm `job_id` tag is always present
- [x] Confirm job-level tags override cluster/command tags on the same key
- [x] Confirm jobs with no tags configured at any level still launch without error