### PR TITLE
FIX(WEB): truncate long job names with TrimText (jobs list + details)

### DIFF
--- a/web/src/modules/Jobs/Helper.tsx
+++ b/web/src/modules/Jobs/Helper.tsx
@@ -6,6 +6,7 @@ import {
   Tag,
   TagProps,
   SortByProps,
+  TrimText,
 } from '@patterninc/react-ui'
 import Link from 'next/link'
 import { formatDateWithTimeZone, myTimezone } from '@/common/Services'
@@ -101,7 +102,13 @@ export const useJobConfig = ({
           children: (row: JobType) => {
             return (
               <div className={sortBy.prop === 'name' ? 'fw-semi-bold' : ''}>
-                <MdashCheck check={!!row.name}>{row.name}</MdashCheck>
+                <MdashCheck check={!!row.name}>
+                  <TrimText
+                    text={row.name}
+                    limit={60}
+                    customClass='whitespace-nowrap'
+                  />
+                </MdashCheck>
               </div>
             )
           },

--- a/web/src/modules/Jobs/JobDetails/JobInformationPane.tsx
+++ b/web/src/modules/Jobs/JobDetails/JobInformationPane.tsx
@@ -3,6 +3,7 @@ import {
   Icon,
   InformationPane,
   ListLoading,
+  TrimText,
 } from '@patterninc/react-ui'
 import { getStatusColor, JobDataTypesProps } from '../Helper'
 import { formatDateWithTimeZone, myTimezone } from '@/common/Services'
@@ -60,7 +61,13 @@ const JobInformationPane = ({
         header={{
           labelAndData: {
             label: 'Job Name',
-            data: <span>{jobData?.name}</span>,
+            data: (
+              <TrimText
+                text={jobData?.name ?? ''}
+                limit={25}
+                customClass='whitespace-nowrap'
+              />
+            ),
             check: !!jobData?.name,
           },
           tag: {


### PR DESCRIPTION
### Summary

Long job names (e.g. `fact_buybox_estimates_seller_daily.check_fact_buybox_estimates_seller_daily_status`) were overflowing / getting cut off in the Job Name column on the Jobs list and in the Job Details header, causing an inconsistent layout.

This switches both spots to react-ui's `TrimText`, which truncates to a character limit, keeps the name on a single line, and reveals the full name on hover.

### Changes

- **Jobs list - Name column** (`web/src/modules/Jobs/Helper.tsx`): render the name via `<TrimText text={row.name} limit={60} customClass='whitespace-nowrap' />` instead of the raw value.
- **Job Details - header** (`web/src/modules/Jobs/JobDetails/JobInformationPane.tsx`): same `TrimText` treatment for the `Job Name` field (`limit={25}`).

### Testing

- Verified in the browser on both the Jobs list and a Job Details page with a long job name: name stays on one line, truncates with `…`, and the full value appears on hover.

### Screenshots
Before - Job Details section, overflow is visible for JOB NAME:
<img width="1728" height="887" alt="before_job_name" src="https://github.com/user-attachments/assets/8a0c2eb7-e0bb-40bc-b7a8-0c25afeffa92" />

After(not the same test case) - Job Details section, JOB NAME trimmed to 25 characters, visible on hovor:
<img width="958" height="298" alt="Screenshot 2026-06-16 at 10 50 02 AM" src="https://github.com/user-attachments/assets/3af9c843-f818-49ba-bd14-dc29abcd38e5" />

After(not the same test case) - Job List section, JOB NAME trimmed to 60 characters, visible on hovor:
<img width="1194" height="783" alt="Screenshot 2026-06-16 at 2 17 53 PM" src="https://github.com/user-attachments/assets/335c2a2b-616c-4170-9a9a-54fbfd36eee1" />

