### PR TITLE
fix: healthchecks for ecs, snowflake and trino

### DIFF
--- a/internal/pkg/object/command/ecs/ecs.go
+++ b/internal/pkg/object/command/ecs/ecs.go
@@ -930,13 +930,5 @@ func (e *commandContext) HealthCheck(ctx context.Context, c *cluster.Cluster) er
 		return fmt.Errorf("ECS cluster %q is not active: %s", clusterName, status)
 	}
 
-	if clusterCtx.MaxTaskCount > 0 {
-		running := int(out.Clusters[0].RunningTasksCount)
-		pending := int(out.Clusters[0].PendingTasksCount)
-		if running+pending >= clusterCtx.MaxTaskCount {
-			return fmt.Errorf("ECS cluster %q at capacity: %d running + %d pending >= max %d", clusterName, running, pending, clusterCtx.MaxTaskCount)
-		}
-	}
-
 	return nil
 }

--- a/internal/pkg/object/command/snowflake/snowflake.go
+++ b/internal/pkg/object/command/snowflake/snowflake.go
@@ -221,20 +221,33 @@ func (s *commandContext) HealthCheck(ctx context.Context, c *cluster.Cluster) er
 		return err
 	}
 
-	state, _ := vals[stateIdx].(string)
+	state := scanToString(vals[stateIdx])
 	switch state {
-	case "STARTED":
+	case "STARTED", "RESUMING":
 		return nil
 	case "SUSPENDED":
-		if autoResumeIdx >= 0 {
-			autoResume, _ := vals[autoResumeIdx].(string)
-			if autoResume == "true" {
-				return nil
-			}
+		if autoResumeIdx >= 0 && scanToString(vals[autoResumeIdx]) == "true" {
+			return nil
 		}
-		return fmt.Errorf("snowflake warehouse %q is suspended with auto_resume disabled", clusterCtx.Warehouse)
+		return fmt.Errorf("snowflake warehouse %q is suspended and auto_resume is not enabled", clusterCtx.Warehouse)
 	default:
 		return fmt.Errorf("snowflake warehouse %q is not ready: state=%s", clusterCtx.Warehouse, state)
+	}
+}
+
+func scanToString(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case []byte:
+		return string(val)
+	case bool:
+		if val {
+			return "true"
+		}
+		return "false"
+	default:
+		return fmt.Sprintf("%v", v)
 	}
 }
 

--- a/internal/pkg/object/command/snowflake/snowflake.go
+++ b/internal/pkg/object/command/snowflake/snowflake.go
@@ -195,12 +195,13 @@ func (s *commandContext) HealthCheck(ctx context.Context, c *cluster.Cluster) er
 		return err
 	}
 
-	// Find the "state" column index
-	stateIdx := -1
+	stateIdx, autoResumeIdx := -1, -1
 	for i, col := range cols {
-		if col == "state" {
+		switch col {
+		case "state":
 			stateIdx = i
-			break
+		case "auto_resume":
+			autoResumeIdx = i
 		}
 	}
 	if stateIdx < 0 {
@@ -221,11 +222,20 @@ func (s *commandContext) HealthCheck(ctx context.Context, c *cluster.Cluster) er
 	}
 
 	state, _ := vals[stateIdx].(string)
-	if state != "STARTED" {
+	switch state {
+	case "STARTED":
+		return nil
+	case "SUSPENDED":
+		if autoResumeIdx >= 0 {
+			autoResume, _ := vals[autoResumeIdx].(string)
+			if autoResume == "true" {
+				return nil
+			}
+		}
+		return fmt.Errorf("snowflake warehouse %q is suspended with auto_resume disabled", clusterCtx.Warehouse)
+	default:
 		return fmt.Errorf("snowflake warehouse %q is not ready: state=%s", clusterCtx.Warehouse, state)
 	}
-
-	return nil
 }
 
 func (s *commandContext) Cleanup(ctx context.Context, jobID string, c *cluster.Cluster) error {

--- a/internal/pkg/object/command/trino/trino.go
+++ b/internal/pkg/object/command/trino/trino.go
@@ -2,7 +2,6 @@ package trino
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -123,39 +122,6 @@ func (t *commandContext) HealthCheck(ctx context.Context, c *cluster.Cluster) er
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("trino /v1/info returned status %d", resp.StatusCode)
-	}
-
-	return t.checkTrinoClusterCapacity(ctx, clusterCtx.Endpoint)
-}
-
-func (t *commandContext) checkTrinoClusterCapacity(ctx context.Context, endpoint string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/v1/cluster", nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("trino /v1/cluster returned status %d", resp.StatusCode)
-	}
-
-	var info struct {
-		ActiveWorkers int `json:"activeWorkers"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return fmt.Errorf("trino /v1/cluster: failed to decode response: %w", err)
-	}
-
-	if info.ActiveWorkers == 0 {
-		return fmt.Errorf("trino cluster has no active workers")
 	}
 
 	return nil


### PR DESCRIPTION
### Description
This pull request updates the health check logic for ECS, Snowflake, and Trino clusters, simplifying capacity checks and improving readiness detection. The main changes involve removing cluster capacity checks for ECS and Trino, and enhancing the Snowflake health check to handle suspended warehouses with auto-resume enabled.

### Changes
**Cluster Health Check Logic Updates:**

* Removed the ECS cluster capacity check by deleting the logic that blocked clusters at or above their maximum task count. (`internal/pkg/object/command/ecs/ecs.go`)
* Removed the Trino cluster capacity check, including the entire `checkTrinoClusterCapacity` method and its invocation, so Trino health checks now only verify the `/v1/info` endpoint. (`internal/pkg/object/command/trino/trino.go`) [[1]](diffhunk://#diff-6a82ae4f05b7a9ff053f5d153fff5970abc07bd7b45365805a365ebeacdf5fcaL128-L160) [[2]](diffhunk://#diff-6a82ae4f05b7a9ff053f5d153fff5970abc07bd7b45365805a365ebeacdf5fcaL5)

**Snowflake Health Check Improvements:**

* Enhanced the Snowflake health check to:
  - Detect the `auto_resume` column index along with `state`.
  - Allow warehouses in the `SUSPENDED` state to pass the health check if `auto_resume` is enabled, otherwise fail with a clear error message.
  - Provide more descriptive error messages for non-ready states. (`internal/pkg/object/command/snowflake/snowflake.go`) [[1]](diffhunk://#diff-cdbfc6fc091fc473b5c5e6b1dd2711e2fa0358111659378624b2072f46a4c7e4L198-R204) [[2]](diffhunk://#diff-cdbfc6fc091fc473b5c5e6b1dd2711e2fa0358111659378624b2072f46a4c7e4L224-L228)