### PR TITLE
HOTFIX: Read final tag from env

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -104,8 +104,8 @@ jobs:
       - name: Create and push manifest list
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create -t ${{ env.IMAGE }}:${{ steps.tagger.outputs.tag }} \
+          docker buildx imagetools create -t ${{ env.IMAGE }}:$${{ env.DOCKER_TAG }} \
             $(printf '${{ env.IMAGE }}@sha256:%s ' *)
 
       - name: Inspect
-        run: docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.tagger.outputs.tag }}
+        run: docker buildx imagetools inspect ${{ env.IMAGE }}:$${{ env.DOCKER_TAG }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -104,8 +104,8 @@ jobs:
       - name: Create and push manifest list
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create -t ${{ env.IMAGE }}:$${{ env.DOCKER_TAG }} \
+          docker buildx imagetools create -t ${{ env.IMAGE }}:${{ env.DOCKER_TAG }} \
             $(printf '${{ env.IMAGE }}@sha256:%s ' *)
 
       - name: Inspect
-        run: docker buildx imagetools inspect ${{ env.IMAGE }}:$${{ env.DOCKER_TAG }}
+        run: docker buildx imagetools inspect ${{ env.IMAGE }}:${{ env.DOCKER_TAG }}


### PR DESCRIPTION
This pull request makes a minor update to the Docker image workflow by switching from using the output of the `tagger` step to the `DOCKER_TAG` environment variable for tagging and inspecting Docker images. This change helps standardize how the tag is referenced throughout the workflow.

* Updated the Docker image tagging and inspection steps in `.github/workflows/docker-image.yml` to use the `DOCKER_TAG` environment variable instead of `${{ steps.tagger.outputs.tag }}` for more consistent and maintainable workflow configuration.