### PR TITLE
Stream S3/Trino/Avro/StarRocks reads instead of buffering full responses

### DIFF
--- a/internal/pkg/aws/s3.go
+++ b/internal/pkg/aws/s3.go
@@ -80,6 +80,44 @@ func ReadFromS3(ctx context.Context, name string) ([]byte, error) {
 
 }
 
+// GetS3ObjectReader returns a streaming reader for an S3 object plus its content length,
+// so callers can copy the body directly to a destination (e.g. an HTTP response) without
+// buffering the whole object into memory. The caller is responsible for closing the reader.
+func GetS3ObjectReader(ctx context.Context, name string) (io.ReadCloser, int64, error) {
+
+	bucket, key, err := parseS3Path(name)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	awsConfig, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	svc := s3.NewFromConfig(awsConfig)
+
+	getObjectOutput, err := svc.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if getObjectOutput == nil || getObjectOutput.Body == nil {
+		return nil, 0, nil
+	}
+
+	contentLength := int64(0)
+	if getObjectOutput.ContentLength != nil {
+		contentLength = *getObjectOutput.ContentLength
+	}
+
+	return getObjectOutput.Body, contentLength, nil
+
+}
+
 func parseS3Path(name string) (string, string, error) {
 
 	// let's parse name

--- a/internal/pkg/heimdall/handler.go
+++ b/internal/pkg/heimdall/handler.go
@@ -20,6 +20,7 @@ const (
 	idKey            = `id`
 	errorKey         = `error`
 	jsonUserKey      = `user`
+	maxPayloadBytes  = 10 << 20 // 10MB cap on inbound job/command/cluster payloads
 )
 
 var (
@@ -72,7 +73,7 @@ func payloadHandler[T any](fn func(context.Context, *T) (any, error)) http.Handl
 		// API request count
 		payloadHandlerMethod.CountRequest()
 
-		data, err := io.ReadAll(r.Body)
+		data, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxPayloadBytes))
 		if err != nil {
 			writeAPIError(w, err, nil)
 			return

--- a/internal/pkg/heimdall/heimdall.go
+++ b/internal/pkg/heimdall/heimdall.go
@@ -200,6 +200,13 @@ func (h *Heimdall) Start() error {
 	router.Path(`/metrics`).HandlerFunc(metricsRouteHandler)
 
 	if os.Getenv("ENABLE_DEBUG") == "true" {
+		// pprof.Index only serves the lookup-based profiles (heap, goroutine, allocs, ...);
+		// cmdline/profile/symbol/trace need their own dedicated handlers registered explicitly,
+		// otherwise CPU profiling (/debug/pprof/profile) 404s.
+		router.HandleFunc(`/debug/pprof/cmdline`, pprof.Cmdline)
+		router.HandleFunc(`/debug/pprof/profile`, pprof.Profile)
+		router.HandleFunc(`/debug/pprof/symbol`, pprof.Symbol)
+		router.HandleFunc(`/debug/pprof/trace`, pprof.Trace)
 		router.PathPrefix(`/debug/pprof/`).HandlerFunc(pprof.Index)
 	}
 	// catch all for APIs

--- a/internal/pkg/heimdall/job.go
+++ b/internal/pkg/heimdall/job.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -335,17 +336,33 @@ func (h *Heimdall) getJobFile(w http.ResponseWriter, r *http.Request) {
 		sourceDirectory = h.ResultDirectory
 	}
 
-	// get the file content
-	readFileFunc := os.ReadFile
 	filenamePath := fmt.Sprintf(jobFileFormat, sourceDirectory, jobID, filename)
+
+	// S3-backed files are streamed directly to the response instead of being buffered
+	// into memory -- these can be multi-hundred-MB job logs / results.
 	if strings.HasPrefix(filenamePath, s3Prefix) {
-		readFileFunc = func(path string) ([]byte, error) {
-			return aws.ReadFromS3(r.Context(), path)
+		body, contentLength, err := aws.GetS3ObjectReader(r.Context(), filenamePath)
+		if err != nil {
+			writeAPIError(w, err, nil)
+			return
 		}
+		if body == nil {
+			writeAPIError(w, fmt.Errorf(formatFileNotFound, filename), nil)
+			return
+		}
+		defer body.Close()
+
+		w.Header().Add(contentTypeKey, contentType)
+		if contentLength > 0 {
+			w.Header().Add(`Content-Length`, strconv.FormatInt(contentLength, 10))
+		}
+		w.WriteHeader(http.StatusOK)
+		io.Copy(w, body)
+		return
 	}
 
 	// get file's content
-	data, err := readFileFunc(filenamePath)
+	data, err := os.ReadFile(filenamePath)
 	if err != nil {
 		writeAPIError(w, err, nil)
 		return

--- a/internal/pkg/object/command/starrocks/backend_client_pool.go
+++ b/internal/pkg/object/command/starrocks/backend_client_pool.go
@@ -78,7 +78,10 @@ func (p *backendClientPool) closeAll() {
 	}
 }
 
-func fetchEndpoint(ctx context.Context, beClients *backendClientPool, endpoint *flight.FlightEndpoint) ([][]any, error) {
+// fetchEndpoint redeems a single BE endpoint's ticket and returns the raw Flight
+// reader so the caller can stream record batches directly instead of draining
+// the whole stream into memory here first.
+func fetchEndpoint(ctx context.Context, beClients *backendClientPool, endpoint *flight.FlightEndpoint) (*flight.Reader, error) {
 
 	client, err := beClients.clientFor(ctx, endpoint)
 	if err != nil {
@@ -89,18 +92,8 @@ func fetchEndpoint(ctx context.Context, beClients *backendClientPool, endpoint *
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch result stream: %v", err)
 	}
-	defer reader.Release()
 
-	rows := make([][]any, 0, 128)
-	for reader.Next() {
-		rows = append(rows, recordToRows(reader.Record())...)
-	}
-
-	if err := reader.Err(); err != nil {
-		return nil, fmt.Errorf("error reading result stream: %v", err)
-	}
-
-	return rows, nil
+	return reader, nil
 
 }
 

--- a/internal/pkg/object/command/starrocks/job_context.go
+++ b/internal/pkg/object/command/starrocks/job_context.go
@@ -3,6 +3,7 @@ package starrocks
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/apache/arrow-go/v18/arrow/flight"
 	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
@@ -69,18 +70,35 @@ func collectResults(ctx context.Context, feClient *flightsql.Client, info *fligh
 	beClients := newBackendClientPool(feClient, dialedEndpoint, useTLS)
 	defer beClients.closeAll()
 
-	// endpoints redeem independently, so fan DoGet out across goroutines
-	// instead of draining them one at a time.
-	rowsByEndpoint := make([][][]any, len(info.Endpoint))
+	out := &result.Result{
+		Columns: columnsFromSchema(schema),
+		Data:    make([][]any, 0, 128),
+	}
+	var mu sync.Mutex
 
+	// endpoints redeem independently, so fan DoGet out across goroutines; each
+	// reader is streamed record-batch by record-batch straight into out.Data
+	// instead of being drained into a per-endpoint buffer first.
 	g, gctx := errgroup.WithContext(ctx)
-	for i, endpoint := range info.Endpoint {
+	for _, endpoint := range info.Endpoint {
 		g.Go(func() error {
-			rows, err := fetchEndpoint(gctx, beClients, endpoint)
+			reader, err := fetchEndpoint(gctx, beClients, endpoint)
 			if err != nil {
 				return err
 			}
-			rowsByEndpoint[i] = rows
+			defer reader.Release()
+
+			for reader.Next() {
+				rows := recordToRows(reader.Record())
+				mu.Lock()
+				out.Data = append(out.Data, rows...)
+				mu.Unlock()
+			}
+
+			if err := reader.Err(); err != nil {
+				return fmt.Errorf("error reading result stream: %v", err)
+			}
+
 			return nil
 		})
 	}
@@ -88,14 +106,6 @@ func collectResults(ctx context.Context, feClient *flightsql.Client, info *fligh
 	if err := g.Wait(); err != nil {
 		collectResultsMethod.CountError("do_get")
 		return nil, err
-	}
-
-	out := &result.Result{
-		Columns: columnsFromSchema(schema),
-		Data:    make([][]any, 0, 128),
-	}
-	for _, rows := range rowsByEndpoint {
-		out.Data = append(out.Data, rows...)
 	}
 
 	return out, nil

--- a/internal/pkg/object/command/starrocks/starrocks.go
+++ b/internal/pkg/object/command/starrocks/starrocks.go
@@ -187,9 +187,11 @@ func (cmd *commandContext) HealthCheck(ctx context.Context, c *cluster.Cluster) 
 	defer beClients.closeAll()
 
 	for _, endpoint := range info.Endpoint {
-		if _, err := fetchEndpoint(ctx, beClients, endpoint); err != nil {
+		reader, err := fetchEndpoint(ctx, beClients, endpoint)
+		if err != nil {
 			return err
 		}
+		reader.Release()
 	}
 
 	return nil

--- a/internal/pkg/object/command/trino/client.go
+++ b/internal/pkg/object/command/trino/client.go
@@ -115,18 +115,16 @@ func (r *request) api(req *http.Request) error {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("unexpected status code [%d]: %s", resp.StatusCode, string(body))
 	}
 
+	// stream-decode the response instead of buffering the full body -- Trino statement-API
+	// responses can carry large result pages and this is polled repeatedly per job.
 	output := &response{}
-	if err := json.Unmarshal(body, output); err != nil {
-		return fmt.Errorf("error [%s]: %s", err, string(body))
+	if err := json.NewDecoder(resp.Body).Decode(output); err != nil {
+		return fmt.Errorf("error decoding trino response: %w", err)
 	}
 
 	// do we have an error?

--- a/internal/pkg/rbac/ranger/client.go
+++ b/internal/pkg/rbac/ranger/client.go
@@ -164,8 +164,6 @@ func (c *client) executeRequest(method string, endpoint string, v interface{}, r
 
 	executeRequestMethod.CountSuccess()
 
-	vals, _ := io.ReadAll(resp.Body)
-	resp.Body = io.NopCloser(bytes.NewReader(vals))
 	if v != nil {
 		return json.NewDecoder(resp.Body).Decode(v)
 	}

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -1,12 +1,10 @@
 package result
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io"
 	"math/big"
 	"regexp"
 	"strconv"
@@ -136,49 +134,69 @@ func FromAvro(uri string) (*Result, error) {
 
 	for _, c := range listObjectsOutput.Contents {
 		if key := *c.Key; strings.HasSuffix(key, avroExtension) {
-			data, err := getS3Object(svc, &s3Parts[0][1], c.Key)
-			if err != nil {
+			if err := readAvroObject(svc, &s3Parts[0][1], c.Key, r); err != nil {
 				return nil, err
-			}
-			ocf, err := goavro.NewOCFReader(bytes.NewReader(data))
-			if err != nil {
-				return nil, err
-			}
-			// if we do not have columns metadata, let's pull it....
-			if len(r.Columns) == 0 {
-				fields := &avroFields{}
-				if err := json.Unmarshal([]byte(ocf.Codec().Schema()), fields); err != nil {
-					return nil, err
-				}
-				r.Columns = fields.Fields
-			}
-			// now let's process data
-			for ocf.Scan() {
-				recordObject, err := ocf.Read()
-				if err != nil {
-					return nil, err
-				}
-				row := make([]any, 0, len(r.Columns))
-				record, ok := recordObject.(map[string]any)
-				if !ok {
-					return nil, fmt.Errorf("failed to parse record. unexpected type: %T", recordObject)
-				}
-				for _, c := range r.Columns {
-					val := record[c.Name]
-					if m, ok := val.(map[string]any); ok && len(m) == 1 {
-						val = extractUnionValue(m, c)
-					}
-					if c.IsDecimal() {
-						val = decodeDecimal(val, c.Scale)
-					}
-					row = append(row, val)
-				}
-				r.Data = append(r.Data, row)
 			}
 		}
 	}
 
 	return r, nil
+
+}
+
+// readAvroObject streams a single Avro object's records directly from its S3 body into r,
+// without buffering the object into memory first -- goavro.NewOCFReader reads sequentially
+// off an io.Reader, so there is no need to materialize the whole file as []byte.
+func readAvroObject(svc *s3.Client, bucket, key *string, r *Result) error {
+
+	resp, err := svc.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: bucket,
+		Key:    key,
+	})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	ocf, err := goavro.NewOCFReader(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	// if we do not have columns metadata, let's pull it....
+	if len(r.Columns) == 0 {
+		fields := &avroFields{}
+		if err := json.Unmarshal([]byte(ocf.Codec().Schema()), fields); err != nil {
+			return err
+		}
+		r.Columns = fields.Fields
+	}
+
+	// now let's process data
+	for ocf.Scan() {
+		recordObject, err := ocf.Read()
+		if err != nil {
+			return err
+		}
+		row := make([]any, 0, len(r.Columns))
+		record, ok := recordObject.(map[string]any)
+		if !ok {
+			return fmt.Errorf("failed to parse record. unexpected type: %T", recordObject)
+		}
+		for _, c := range r.Columns {
+			val := record[c.Name]
+			if m, ok := val.(map[string]any); ok && len(m) == 1 {
+				val = extractUnionValue(m, c)
+			}
+			if c.IsDecimal() {
+				val = decodeDecimal(val, c.Scale)
+			}
+			row = append(row, val)
+		}
+		r.Data = append(r.Data, row)
+	}
+
+	return nil
 
 }
 
@@ -288,20 +306,4 @@ func decodeDecimal(val any, scale int) any {
 	divisor := new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(scale)), nil))
 	result, _ := new(big.Float).Quo(new(big.Float).SetInt(unscaled), divisor).Float64()
 	return result
-}
-
-func getS3Object(svc *s3.Client, bucket, key *string) ([]byte, error) {
-
-	resp, err := svc.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: bucket,
-		Key:    key,
-	})
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	// Read the file content
-	return io.ReadAll(resp.Body)
-
 }


### PR DESCRIPTION
## Summary
- Fixes the unbounded `io.ReadAll` allocation hotspots identified in the v6/v7 pprof rounds: the job-file S3 download handler (`internal/pkg/heimdall/job.go`), the Trino statement-API poller (`internal/pkg/object/command/trino/client.go`), and the Avro result reader (`pkg/result/result.go`) all buffered entire response bodies into memory before use -- they now stream directly via `io.Copy`/`io.Reader`/`json.Decoder`, matching what production profiling flagged as the two dominant OOM-relevant allocation sites (31-54% and 21-43% of heap alloc respectively).
- Registers the missing pprof CPU-profile handlers (`cmdline`/`profile`/`symbol`/`trace`) in `internal/pkg/heimdall/heimdall.go` -- `/debug/pprof/profile` was silently 404ing in every prior profiling round since only `pprof.Index` was registered.
- Caps inbound API payload size via `http.MaxBytesReader` (defense-in-depth) and removes a pointless read-then-rewrap in the Ranger RBAC client.
- StarRocks' backend fetch (`internal/pkg/object/command/starrocks/`) now streams each Flight reader's record batches directly into the shared result instead of draining every endpoint into its own buffer first.

## Test plan
- [x] `go build`/`go vet`/full test suite pass
- [x] Manually built every touched plugin with `-buildmode=plugin` (trino, clickhouse, sparkeks, starrocks, etc.)
- [x] Confirmed `/debug/pprof/profile` now returns 200 (was 404) on a locally-built instance of this branch
- [x] Validated the new S3 streaming reader against a local MinIO instance: byte-identical output vs. the old buffered read (SHA256 match)
- [x] End-to-end job submit/poll/file-download regression check against a local instance passed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)