### PR TITLE
FIX: Stream S3 job-file downloads instead of buffering into memory

### DIFF
--- a/internal/pkg/aws/glue.go
+++ b/internal/pkg/aws/glue.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -33,8 +34,17 @@ func GetTableMetadata(ctx context.Context, catalogID, tableName string) ([]byte,
 		return nil, err
 	}
 
-	// let's pull the file content
-	return ReadFromS3(ctx, location)
+	// table metadata is a small JSON file, so it's fine to read it fully here
+	body, _, err := ReadFromS3(ctx, location)
+	if err != nil {
+		return nil, err
+	}
+	if body == nil {
+		return nil, nil
+	}
+	defer body.Close()
+
+	return io.ReadAll(body)
 
 }
 

--- a/internal/pkg/aws/s3.go
+++ b/internal/pkg/aws/s3.go
@@ -46,44 +46,9 @@ func WriteToS3(ctx context.Context, name string, data []byte, _ os.FileMode) err
 
 }
 
-func ReadFromS3(ctx context.Context, name string) ([]byte, error) {
-
-	bucket, key, err := parseS3Path(name)
-	if err != nil {
-		return nil, err
-	}
-
-	// upload file
-	awsConfig, err := config.LoadDefaultConfig(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create an S3 client
-	svc := s3.NewFromConfig(awsConfig)
-
-	// Create a PutObject request to upload the file
-	getObjectOutput, err := svc.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: &bucket,
-		Key:    &key,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if getObjectOutput != nil && getObjectOutput.Body != nil {
-		defer getObjectOutput.Body.Close()
-		return io.ReadAll(getObjectOutput.Body)
-	}
-
-	return nil, nil
-
-}
-
-// GetS3ObjectReader returns a streaming reader for an S3 object plus its content length,
-// so callers can copy the body directly to a destination (e.g. an HTTP response) without
-// buffering the whole object into memory. The caller is responsible for closing the reader.
-func GetS3ObjectReader(ctx context.Context, name string) (io.ReadCloser, int64, error) {
+// ReadFromS3 returns the object body as a streaming reader plus its content length.
+// The caller is responsible for closing the reader.
+func ReadFromS3(ctx context.Context, name string) (io.ReadCloser, int64, error) {
 
 	bucket, key, err := parseS3Path(name)
 	if err != nil {

--- a/internal/pkg/aws/s3.go
+++ b/internal/pkg/aws/s3.go
@@ -80,6 +80,44 @@ func ReadFromS3(ctx context.Context, name string) ([]byte, error) {
 
 }
 
+// GetS3ObjectReader returns a streaming reader for an S3 object plus its content length,
+// so callers can copy the body directly to a destination (e.g. an HTTP response) without
+// buffering the whole object into memory. The caller is responsible for closing the reader.
+func GetS3ObjectReader(ctx context.Context, name string) (io.ReadCloser, int64, error) {
+
+	bucket, key, err := parseS3Path(name)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	awsConfig, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	svc := s3.NewFromConfig(awsConfig)
+
+	getObjectOutput, err := svc.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if getObjectOutput == nil || getObjectOutput.Body == nil {
+		return nil, 0, nil
+	}
+
+	contentLength := int64(0)
+	if getObjectOutput.ContentLength != nil {
+		contentLength = *getObjectOutput.ContentLength
+	}
+
+	return getObjectOutput.Body, contentLength, nil
+
+}
+
 func parseS3Path(name string) (string, string, error) {
 
 	// let's parse name

--- a/internal/pkg/heimdall/job.go
+++ b/internal/pkg/heimdall/job.go
@@ -339,10 +339,8 @@ func (h *Heimdall) getJobFile(w http.ResponseWriter, r *http.Request) {
 
 	filenamePath := fmt.Sprintf(jobFileFormat, sourceDirectory, jobID, filename)
 
-	// S3-backed files are streamed directly to the response instead of being buffered
-	// into memory -- these can be multi-hundred-MB job logs / results.
 	if strings.HasPrefix(filenamePath, s3Prefix) {
-		body, contentLength, err := aws.GetS3ObjectReader(r.Context(), filenamePath)
+		body, contentLength, err := aws.ReadFromS3(r.Context(), filenamePath)
 		if err != nil {
 			writeAPIError(w, err, nil)
 			return
@@ -358,9 +356,8 @@ func (h *Heimdall) getJobFile(w http.ResponseWriter, r *http.Request) {
 			w.Header().Add(`Content-Length`, strconv.FormatInt(contentLength, 10))
 		}
 		w.WriteHeader(http.StatusOK)
+		// status is already written, so a copy error can't change the response -- just record it.
 		if _, err := io.Copy(w, body); err != nil {
-			// the 200 status is already on the wire at this point, so the client sees a
-			// truncated body -- at minimum, record the failure server-side.
 			getJobFileMethod.LogAndCountError(err, "stream_s3_body")
 		}
 		return

--- a/internal/pkg/heimdall/job.go
+++ b/internal/pkg/heimdall/job.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -335,17 +336,33 @@ func (h *Heimdall) getJobFile(w http.ResponseWriter, r *http.Request) {
 		sourceDirectory = h.ResultDirectory
 	}
 
-	// get the file content
-	readFileFunc := os.ReadFile
 	filenamePath := fmt.Sprintf(jobFileFormat, sourceDirectory, jobID, filename)
+
+	// S3-backed files are streamed directly to the response instead of being buffered
+	// into memory -- these can be multi-hundred-MB job logs / results.
 	if strings.HasPrefix(filenamePath, s3Prefix) {
-		readFileFunc = func(path string) ([]byte, error) {
-			return aws.ReadFromS3(r.Context(), path)
+		body, contentLength, err := aws.GetS3ObjectReader(r.Context(), filenamePath)
+		if err != nil {
+			writeAPIError(w, err, nil)
+			return
 		}
+		if body == nil {
+			writeAPIError(w, fmt.Errorf(formatFileNotFound, filename), nil)
+			return
+		}
+		defer body.Close()
+
+		w.Header().Add(contentTypeKey, contentType)
+		if contentLength > 0 {
+			w.Header().Add(`Content-Length`, strconv.FormatInt(contentLength, 10))
+		}
+		w.WriteHeader(http.StatusOK)
+		io.Copy(w, body)
+		return
 	}
 
 	// get file's content
-	data, err := readFileFunc(filenamePath)
+	data, err := os.ReadFile(filenamePath)
 	if err != nil {
 		writeAPIError(w, err, nil)
 		return

--- a/internal/pkg/heimdall/job.go
+++ b/internal/pkg/heimdall/job.go
@@ -46,6 +46,7 @@ var (
 	runJobMethod                  = telemetry.NewMethod("runJob", "heimdall")
 	cancelJobMethod               = telemetry.NewMethod("db_connection", "cancel_job")
 	renderAttributesMethod        = telemetry.NewMethod("renderAttributes", "heimdall")
+	getJobFileMethod              = telemetry.NewMethod("getJobFile", "heimdall")
 )
 
 //go:embed queries/job/status_cancel_update.sql
@@ -357,7 +358,11 @@ func (h *Heimdall) getJobFile(w http.ResponseWriter, r *http.Request) {
 			w.Header().Add(`Content-Length`, strconv.FormatInt(contentLength, 10))
 		}
 		w.WriteHeader(http.StatusOK)
-		io.Copy(w, body)
+		if _, err := io.Copy(w, body); err != nil {
+			// the 200 status is already on the wire at this point, so the client sees a
+			// truncated body -- at minimum, record the failure server-side.
+			getJobFileMethod.LogAndCountError(err, "stream_s3_body")
+		}
 		return
 	}
 


### PR DESCRIPTION
## Summary
- `GET /api/v1/job/{id}/{file}` buffered the entire S3-backed job log/result file into a `[]byte` (`aws.ReadFromS3`) before writing it to the HTTP response. This was the **#1 allocation site** in production pprof profiling (31-54% of per-sample heap allocation), hit on every download of an S3-stored job artifact.
- `aws.ReadFromS3` now returns the object body as a streaming `io.ReadCloser` plus its content length, instead of fully buffering it into memory. Its one other caller, `glue.GetTableMetadata`, reads the body fully at the call site since it genuinely needs the bytes (a small JSON metadata file) -- no behavior change there.
- `getJobFile` streams S3-backed files directly to the response via `io.Copy`, setting `Content-Length` from the object's metadata, and records (via telemetry) if the copy fails mid-stream after the `200` has already been written. The local-disk (`os.ReadFile`) path is unchanged.

This is slice 1 of a larger set of buffered-reading fixes found via pprof analysis. Remaining slices (Trino stream-decode, Avro stream read, pprof CPU-profile registration, payload size cap, Ranger client cleanup, StarRocks streaming) will follow separately.

## Testing
- `go build ./...`, `go vet`, and the full `go test ./internal/... ./pkg/...` suite pass on this branch.

Test (against archived job): 
- Job id: 00000066-5a19-4623-9115-759a8d5720d5
- File /stdout
<img width="1008" height="353" alt="image" src="https://github.com/user-attachments/assets/30a099ed-cdc9-4a6d-825d-47d7870d0d92" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)