### PR TITLE
FIX: 404 status for result not found

### DIFF
--- a/internal/pkg/heimdall/handler.go
+++ b/internal/pkg/heimdall/handler.go
@@ -56,6 +56,8 @@ func statusForError(err error) int {
 		return http.StatusForbidden
 	case errors.Is(err, ErrNoCaller):
 		return http.StatusUnauthorized
+	case errors.Is(err, ErrResultNotReady):
+		return http.StatusNotFound
 	default:
 		return http.StatusInternalServerError
 	}


### PR DESCRIPTION
This pull request introduces an update to the error handling logic in the `statusForError` function. Specifically, it adds a case to return a 404 Not Found status when the `ErrResultNotReady` error is encountered to match existing behaviour of 404 status if file is not yet available on s3.


Error handling improvements:

* Updated the `statusForError` function in `internal/pkg/heimdall/handler.go` to return `http.StatusNotFound` (404) when the error matches `ErrResultNotReady`.