### PR TITLE
feat: limit access to job file endpoints to only the same user as requester

### DIFF
--- a/internal/pkg/heimdall/job.go
+++ b/internal/pkg/heimdall/job.go
@@ -344,13 +344,13 @@ func (h *Heimdall) getJobFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// let's validate jobID we got
-	jobResult, err := h.getJobStatus(r.Context(), &jobRequest{ID: jobID})
+	jobStatusResult, err := h.getJobStatus(r.Context(), &jobRequest{ID: jobID})
 	if err != nil {
 		writeAPIError(w, err, nil)
 		return
 	}
 
-	j, ok := jobResult.(*job.Job)
+	j, ok := jobStatusResult.(*job.Job)
 	if !ok {
 		writeAPIError(w, ErrUnknownJobID, nil)
 		return
@@ -362,6 +362,7 @@ func (h *Heimdall) getJobFile(w http.ResponseWriter, r *http.Request) {
 			writeAPIError(w, ErrCallerNotAllowed, nil)
 			return
 		}
+		// if failed, we don't have a result file to return
 		if j.Status != jobStatus.Succeeded {
 			writeAPIError(w, ErrResultNotReady, nil)
 			return

--- a/internal/pkg/heimdall/job.go
+++ b/internal/pkg/heimdall/job.go
@@ -350,6 +350,12 @@ func (h *Heimdall) getJobFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// only allow same user to access the job files
+	if j, ok := jobStatusResult.(*job.Job); !ok || j.User != getUsername(r) {
+		writeAPIError(w, ErrCallerNotAllowed, nil)
+		return
+	}
+
 	if filename == resultFile {
 		if j, ok := jobStatusResult.(*job.Job); !ok || j.Status != jobStatus.Succeeded {
 			writeAPIError(w, ErrResultNotReady, nil)

--- a/internal/pkg/heimdall/job.go
+++ b/internal/pkg/heimdall/job.go
@@ -356,15 +356,16 @@ func (h *Heimdall) getJobFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// only allow same user to access the job files
-	if j.User != getUsername(r) {
-		writeAPIError(w, ErrCallerNotAllowed, nil)
-		return
-	}
-
-	if filename == resultFile && j.Status != jobStatus.Succeeded {
-		writeAPIError(w, ErrResultNotReady, nil)
-		return
+	if filename == resultFile {
+		// only allow same user to access the job result file
+		if j.User != getUsername(r) {
+			writeAPIError(w, ErrCallerNotAllowed, nil)
+			return
+		}
+		if j.Status != jobStatus.Succeeded {
+			writeAPIError(w, ErrResultNotReady, nil)
+			return
+		}
 	}
 
 	// set context of the requested file

--- a/internal/pkg/heimdall/job.go
+++ b/internal/pkg/heimdall/job.go
@@ -344,23 +344,27 @@ func (h *Heimdall) getJobFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// let's validate jobID we got
-	jobStatusResult, err := h.getJobStatus(r.Context(), &jobRequest{ID: jobID})
+	jobResult, err := h.getJob(r.Context(), &jobRequest{ID: jobID})
 	if err != nil {
 		writeAPIError(w, err, nil)
 		return
 	}
 
+	j, ok := jobResult.(*job.Job)
+	if !ok {
+		writeAPIError(w, ErrUnknownJobID, nil)
+		return
+	}
+
 	// only allow same user to access the job files
-	if j, ok := jobStatusResult.(*job.Job); !ok || j.User != getUsername(r) {
+	if j.User != getUsername(r) {
 		writeAPIError(w, ErrCallerNotAllowed, nil)
 		return
 	}
 
-	if filename == resultFile {
-		if j, ok := jobStatusResult.(*job.Job); !ok || j.Status != jobStatus.Succeeded {
-			writeAPIError(w, ErrResultNotReady, nil)
-			return
-		}
+	if filename == resultFile && j.Status != jobStatus.Succeeded {
+		writeAPIError(w, ErrResultNotReady, nil)
+		return
 	}
 
 	// set context of the requested file

--- a/internal/pkg/heimdall/job.go
+++ b/internal/pkg/heimdall/job.go
@@ -344,7 +344,7 @@ func (h *Heimdall) getJobFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// let's validate jobID we got
-	jobResult, err := h.getJob(r.Context(), &jobRequest{ID: jobID})
+	jobResult, err := h.getJobStatus(r.Context(), &jobRequest{ID: jobID})
 	if err != nil {
 		writeAPIError(w, err, nil)
 		return

--- a/internal/pkg/heimdall/job_dal.go
+++ b/internal/pkg/heimdall/job_dal.go
@@ -517,7 +517,7 @@ func (h *Heimdall) getJobStatus(ctx context.Context, j *jobRequest) (any, error)
 
 	r := &job.Job{}
 
-	if err := row.Scan(&r.Status, &r.Error, &r.UpdatedAt); err != nil {
+	if err := row.Scan(&r.Status, &r.Error, &r.UpdatedAt, &r.User); err != nil {
 		if err == sql.ErrNoRows {
 			getJobStatusMethod.LogAndCountError(ErrUnknownJobID, "query")
 			return nil, ErrUnknownJobID

--- a/internal/pkg/heimdall/job_dal.go
+++ b/internal/pkg/heimdall/job_dal.go
@@ -248,12 +248,12 @@ type sortColumn struct {
 }
 
 type resolvedSort struct {
-	orderKey  string     
-	column    sortColumn 
-	sorted    bool       
-	expr      string     
-	direction string     
-	cmp       string     
+	orderKey  string
+	column    sortColumn
+	sorted    bool
+	expr      string
+	direction string
+	cmp       string
 }
 
 func resolveSortColumns(f *database.Filter) resolvedSort {

--- a/internal/pkg/heimdall/queries/job/status_select.sql
+++ b/internal/pkg/heimdall/queries/job/status_select.sql
@@ -1,7 +1,8 @@
 select
     j.job_status_id,
     j.job_error,
-    j.updated_at
+    j.updated_at,
+    j.username
 from
     jobs j
 where

--- a/internal/pkg/object/command/sparkeks/sparkeks.go
+++ b/internal/pkg/object/command/sparkeks/sparkeks.go
@@ -106,9 +106,9 @@ type commandContext struct {
 }
 
 type jobParameters struct {
-	Properties map[string]string `yaml:"properties,omitempty" json:"properties,omitempty"`
-	EntryPoint string `yaml:"entry_point,omitempty" json:"entry_point,omitempty"`
-	ApplicationType string `yaml:"application_type,omitempty" json:"application_type,omitempty"`
+	Properties      map[string]string `yaml:"properties,omitempty" json:"properties,omitempty"`
+	EntryPoint      string            `yaml:"entry_point,omitempty" json:"entry_point,omitempty"`
+	ApplicationType string            `yaml:"application_type,omitempty" json:"application_type,omitempty"`
 }
 
 type jobContext struct {
@@ -481,7 +481,6 @@ func uploadFileToS3(ctx context.Context, awsConfig aws.Config, fileURI, content 
 func updateS3ToS3aURI(uri string) string {
 	return strings.ReplaceAll(uri, s3Prefix, s3aPrefix)
 }
-
 
 // getS3FileURI finds a file in an S3 directory that matches the given extension.
 func getS3FileURI(ctx context.Context, awsConfig aws.Config, directoryURI, matchingExtension string) (string, error) {

--- a/pkg/object/job/job.go
+++ b/pkg/object/job/job.go
@@ -10,21 +10,21 @@ import (
 )
 
 type Job struct {
-	object.Object      `yaml:",inline" json:",inline"`
-	Status             status.Status        `yaml:"status,omitempty" json:"status,omitempty"`
-	IsSync             bool                 `yaml:"is_sync,omitempty" json:"is_sync,omitempty"`
-	StoreResultSync    bool                 `yaml:"store_result_sync,omitempty" json:"store_result_sync,omitempty"`
-	Error              string               `yaml:"error,omitempty" json:"error,omitempty"`
-	CommandCriteria    *set.Set[string]     `yaml:"command_criteria,omitempty" json:"command_criteria,omitempty"`
-	ClusterCriteria    *set.Set[string]     `yaml:"cluster_criteria,omitempty" json:"cluster_criteria,omitempty"`
-	CommandID          string               `yaml:"command_id,omitempty" json:"command_id,omitempty"`
-	CommandName        string               `yaml:"command_name,omitempty" json:"command_name,omitempty"`
-	ClusterID          string               `yaml:"cluster_id,omitempty" json:"cluster_id,omitempty"`
-	ClusterName        string               `yaml:"cluster_name,omitempty" json:"cluster_name,omitempty"`
-	CanceledBy         string               `yaml:"canceled_by,omitempty" json:"canceled_by,omitempty"`
-	JobAttributes map[string]Attribute `yaml:"job_attributes,omitempty" json:"job_attributes,omitempty"`
-	Result             *result.Result       `yaml:"result,omitempty" json:"result,omitempty"`
-	outputs            map[string]string
+	object.Object   `yaml:",inline" json:",inline"`
+	Status          status.Status        `yaml:"status,omitempty" json:"status,omitempty"`
+	IsSync          bool                 `yaml:"is_sync,omitempty" json:"is_sync,omitempty"`
+	StoreResultSync bool                 `yaml:"store_result_sync,omitempty" json:"store_result_sync,omitempty"`
+	Error           string               `yaml:"error,omitempty" json:"error,omitempty"`
+	CommandCriteria *set.Set[string]     `yaml:"command_criteria,omitempty" json:"command_criteria,omitempty"`
+	ClusterCriteria *set.Set[string]     `yaml:"cluster_criteria,omitempty" json:"cluster_criteria,omitempty"`
+	CommandID       string               `yaml:"command_id,omitempty" json:"command_id,omitempty"`
+	CommandName     string               `yaml:"command_name,omitempty" json:"command_name,omitempty"`
+	ClusterID       string               `yaml:"cluster_id,omitempty" json:"cluster_id,omitempty"`
+	ClusterName     string               `yaml:"cluster_name,omitempty" json:"cluster_name,omitempty"`
+	CanceledBy      string               `yaml:"canceled_by,omitempty" json:"canceled_by,omitempty"`
+	JobAttributes   map[string]Attribute `yaml:"job_attributes,omitempty" json:"job_attributes,omitempty"`
+	Result          *result.Result       `yaml:"result,omitempty" json:"result,omitempty"`
+	outputs         map[string]string
 }
 
 // Attribute kinds for JobAttributes. Kind tells the UI how to render Value.


### PR DESCRIPTION
## PR details
### Background
`/job/{id}/result` had no ownership check. Any caller who knew or guessed a job ID could read another user's job result, even without identifying themselves. Heimdall already identifies the caller via the `auth_header` plugin (`X-Heimdall-User`, stored as `j.User` on job creation), so the fix enforces that the requester matches the job's owner before serving the result file.

### Changes
- Added an ownership check in `getJobFile` (`internal/pkg/heimdall/job.go`), scoped to the `result` file: the job is looked up via `getJobStatus` and its `User` compared against `getUsername(r)` (the caller identity from the existing auth middleware); mismatches are rejected with `ErrCallerNotAllowed` (403). `stdout`/`stderr` are unaffected — no ownership restriction is added for those.
- Extended `queries/job/status_select.sql` to also select `j.username`, and scan it into `r.User` in `getJobStatus` (`job_dal.go`), so the ownership check can run off the existing lightweight status query instead of the full `getJob` lookup (which loads job context/tags and would have made the file-download path heavier and introduced unrelated failure modes — per review feedback).
- Minor cleanup: consolidated the type-assertion on the fetched job, trailing-whitespace/gofmt fix in `job_dal.go`.

#### Types of changes
- [x] Security fix / access control

### Tests
Ran the backend locally (postgres + heimdall API), submitted a `ping` job as user `alice`, and hit `/job/{id}/result` and `/job/{id}/stdout`:
- `alice` (owner) `result`: `200 OK`, correct body
- `bob` (non-owner) `result`: `403 caller is not allowed to run this command`
- no `X-Heimdall-User` header `result`: `403 caller is not allowed to run this command`
- `alice` `stdout`: `200 OK` (unrestricted, as intended)
- `bob` `stdout`: `200 OK` (unrestricted, as intended)

`go build ./internal/... ./pkg/...` passes.

### Impact
Restricts `/job/{id}/result` to the job's owner only; any other caller now gets `403` there. `/job/{id}/stdout` and `/job/{id}/stderr` remain unchanged (no access restriction). No schema or API contract changes beyond the new `403` response for `result`.