### PR TITLE
Starrocks db connection close

### DIFF
--- a/internal/pkg/object/command/starrocks/job_context.go
+++ b/internal/pkg/object/command/starrocks/job_context.go
@@ -30,9 +30,7 @@ func (j *jobContext) withAuth(ctx context.Context) context.Context {
 }
 
 func (j *jobContext) close() {
-	if j.client != nil {
-		j.client.Client.Close()
-	}
+	closeFlightClient(j.client, j.authToken)
 }
 
 func (j *jobContext) execute(ctx context.Context) (*result.Result, error) {

--- a/internal/pkg/object/command/starrocks/starrocks.go
+++ b/internal/pkg/object/command/starrocks/starrocks.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	serviceName    = "starrocks"
-	authHeaderName = "authorization"
+	serviceName         = "starrocks"
+	authHeaderName      = "authorization"
+	closeSessionTimeout = 5 * time.Second
 )
 
 var (
@@ -126,6 +127,7 @@ func connect(ctx context.Context, endpoint string, useTLS bool, username, passwo
 
 	authCtx, err := flightClient.Client.AuthenticateBasicToken(ctx, username, password)
 	if err != nil {
+		flightClient.Close()
 		return nil, "", fmt.Errorf("failed to authenticate with StarRocks Flight SQL server: %v", err)
 	}
 
@@ -160,6 +162,23 @@ func dialFlightClient(ctx context.Context, endpoint string, useTLS bool) (*fligh
 
 }
 
+// closeFlightClient sends CloseSession (StarRocks keeps the FE session until this RPC), then closes gRPC.
+func closeFlightClient(client *flightsql.Client, token string) {
+	if client == nil {
+		return
+	}
+	defer client.Close()
+
+	if token == `` {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), closeSessionTimeout)
+	defer cancel()
+	ctx = metadata.AppendToOutgoingContext(ctx, authHeaderName, token)
+	_, _ = client.CloseSession(ctx, &flight.CloseSessionRequest{})
+}
+
 // HealthCheck implements the plugin.HealthChecker interface
 func (cmd *commandContext) HealthCheck(ctx context.Context, c *cluster.Cluster) error {
 
@@ -174,7 +193,7 @@ func (cmd *commandContext) HealthCheck(ctx context.Context, c *cluster.Cluster) 
 	if err != nil {
 		return err
 	}
-	defer client.Client.Close()
+	defer closeFlightClient(client, token)
 
 	ctx = metadata.AppendToOutgoingContext(ctx, authHeaderName, token)
 


### PR DESCRIPTION
## Summary
- Closing the gRPC client was not enough: StarRocks keeps the FE Flight SQL session in its token cache (visible in `SHOW PROCESSLIST`) until `CloseSession` is sent with the handshake bearer token, or until `wait_timeout` (default 8h).
- `closeFlightClient` now sends `CloseSession` with that token, then closes the gRPC connection. Same path for job cleanup and health checks.
- Also closes the client if authentication fails, so a half-open socket is not left behind.

## Test plan
- [ ] Run a StarRocks query through Heimdall and confirm the FE session disappears from `SHOW PROCESSLIST` immediately after the job finishes (not after 8h).
- [ ] Confirm health checks do not leave sessions behind.
- [ ] Confirm a failed auth attempt does not leak a gRPC connection.
- [ ] Confirm a cancelled/timed-out job still closes the session (cleanup uses a 5s independent timeout, not the job context).