### PR TITLE
fix: glue health check should probe configured catalog_id

### DIFF
--- a/internal/pkg/object/command/glue/glue.go
+++ b/internal/pkg/object/command/glue/glue.go
@@ -67,8 +67,11 @@ func (g *commandContext) HealthCheck(ctx context.Context, _ *cluster.Cluster) er
 	}
 
 	glueClient := glue.NewFromConfig(cfg)
-	maxResults := awssdk.Int32(1)
-	_, err = glueClient.GetDatabases(ctx, &glue.GetDatabasesInput{MaxResults: maxResults})
+	input := &glue.GetDatabasesInput{
+		MaxResults: awssdk.Int32(1),
+		CatalogId:  awssdk.String(g.CatalogID),
+	}
+	_, err = glueClient.GetDatabases(ctx, input)
 	return err
 }
 


### PR DESCRIPTION
## Problem

The `/clusters/health` glue health check calls `glue:GetDatabases` with no `CatalogId`, so it always probes the **default catalog for the account the task role runs in** — not the `catalog_id` actually configured for the glue command (`842676014003` in prod config). This is failing:

```
AccessDeniedException: User: arn:aws:sts::1226xxxxx428:assumed-role/<heimdall-aws-identity>/...
is not authorized to perform: glue:GetDatabases on resource:
arn:aws:glue:us-west-2:1226xxxxx428:catalog
```
The `glue` plugin does not have flexibility to define catalog arn on which it wants to perform health check. Bases on the role/identity assigned it will try health check default catalog within same AWS account.

## Fix

Pass the command's configured `CatalogId` through to `GetDatabases`, so the health check validates access to the catalog the command actually depends on, instead of an unrelated default catalog.

## Testing

- `./build.sh --go` — all commands and plugins (including `glue`) build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)